### PR TITLE
[Fix] Object method should accept empty indexes

### DIFF
--- a/dbcollection/loader.py
+++ b/dbcollection/loader.py
@@ -195,7 +195,10 @@ class DatasetLoader:
             idx = list(range(0, self.size(set_name)[0]))
         else:
             if isinstance(idx, list):
-                assert min(idx) >= 0, 'list must have indexes >= 0: {}'.format(idx)
+                if any(idx):
+                    assert min(idx) >= 0, 'list must have indexes >= 0: {}'.format(idx)
+                else:
+                    idx = list(range(0, self.size(set_name)[0]))
             else:
                 assert idx >= 0, 'idx must be >=0: {}'.format(idx)
 

--- a/dbcollection/tests/test_loader.py
+++ b/dbcollection/tests/test_loader.py
@@ -59,6 +59,9 @@ def test_object_two(output, index):
 def test_object_no_index():
     assert((60000, 2) == loader.object('train').shape)
 
+def test_object_empty_index():
+    assert((60000, 2) == loader.object('train', []).shape)
+
 @pytest.mark.parametrize("field_name, output", [
     ('classes', [10, 2]),
     ('images', [60000, 28, 28]),

--- a/dbcollection/tests/test_loader.py
+++ b/dbcollection/tests/test_loader.py
@@ -56,6 +56,9 @@ def test_object_two(output, index):
     assert(output == loader.object('train', index).tolist())
 
 
+def test_object_no_index():
+    assert((60000, 2) == loader.object('train').shape)
+
 @pytest.mark.parametrize("field_name, output", [
     ('classes', [10, 2]),
     ('images', [60000, 28, 28]),


### PR DESCRIPTION
This pull request fixes the behaviour of the `.object()` method to match the behaviour of the `.get()` method when no indexes are input to the method.