### PR TITLE
[Fix] Convert the default task name to its related task

### DIFF
--- a/dbcollection/datasets/dblist.py
+++ b/dbcollection/datasets/dblist.py
@@ -55,16 +55,33 @@ datasets.update(pedestrian_detection) # pedestrian detection/recognition
 datasets.update(human_pose) # human pose
 
 
+
+#---------------------------------------------------------
+# Other functions
+#---------------------------------------------------------
+
+def fetch_default_task_name(name):
+    """Returns the real task name associated to the default tag."""
+    assert name, 'Must provide a name for the dataset.'
+    return datasets[name].default_task
+
+
+def dataset_tasks(name):
+    """Returns a list of available tasks for a dataset."""
+    assert name, 'Must provide a name for the dataset.'
+    constructor = datasets[name]
+    db_loader = constructor('nan', 'nan', False, False)  # init with empty data
+    tasks = sorted(db_loader.get_all_tasks())
+    tasks.remove('default')
+    return tasks
+
+
 def available_datasets():
     """
     Returns a dictionary with all the available datasets and
     their available tasks.
     """
     out = {}
-    for db in sorted(datasets):
-        constructor = datasets[db]
-        db_loader = constructor('nan', 'nan', False, False)  # init with empty data
-        tasks = sorted(db_loader.get_all_tasks())
-        tasks.remove('default')
-        out[db] = tasks
+    for db_name in sorted(datasets):
+        out[db_name] = dataset_tasks(db_name)
     return out

--- a/dbcollection/manager.py
+++ b/dbcollection/manager.py
@@ -9,7 +9,7 @@ import json
 import shutil
 
 import dbcollection.datasets.funs as dataset
-from dbcollection.datasets.dblist import available_datasets
+from dbcollection.datasets.dblist import available_datasets, fetch_default_task_name
 from dbcollection.cache import CacheManager
 from dbcollection.loader import DatasetLoader
 
@@ -167,6 +167,10 @@ def load(name=None, task='default', data_dir=None, verbose=True, is_test=False):
 
     # Load a cache manager object
     cache_manager = CacheManager(is_test)
+
+    # convert task if equal to 'default'
+    if task == 'default':
+        task = fetch_default_task_name(name)
 
     # check if dataset exists. If not attempt to download the dataset
     if not cache_manager.exists_dataset(name):


### PR DESCRIPTION
Replace the default task with the name of the original task associated to it in order to reduce disk space and to display this info in the loader class.