### PR TITLE
Feature: Add cache reload method

### DIFF
--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -21,6 +21,8 @@ class CacheManager:
         Cache file path + name.
     default_dir : str
         Default directory for the cache.
+    data : dict
+        Cache contents.
     """
 
     def __init__(self, is_test=False):
@@ -585,3 +587,8 @@ class CacheManager:
                 for cat_name in self.data['category']:
                     if name in self.data['category'][cat_name]:
                         print('   > {}: '.format(cat_name))
+
+
+    def reload_cache(self):
+        """Reload the cache file contents."""
+        self.data = self.read_data_cache()

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -11,7 +11,7 @@ import json
 
 
 class CacheManager:
-    """ Class to manage the dbcollection cache data
+    """Class to manage the dbcollection cache data
 
     Attributes
     ----------
@@ -21,6 +21,8 @@ class CacheManager:
         Cache file path + name.
     default_dir : str
         Default directory for the cache.
+    download_dir : str
+        default save dir path for downloaded data.
     data : dict
         Cache contents.
     """
@@ -71,6 +73,30 @@ class CacheManager:
         """Create the main dir to store all metadata files."""
         if not os.path.exists(self.default_dir):
             os.makedirs(self.default_dir)
+
+
+    def set_download_dir(self, path):
+        """Set the default save dir path for downloaded data."""
+        assert path, 'Must input a non-empty path.'
+        self.data['info']['default_download_dir'] = path
+
+
+    def reset_download_dir(self):
+        """Reset the default download dir."""
+        return self.set_download_dir('')
+
+
+    @property
+    def download_dir(self):
+        """Default save dir path for downloaded data."""
+        return self.data['info']['default_download_dir']
+
+
+    @download_dir.setter
+    def download_dir(self, path):
+        """Set the default save dir path for downloaded data."""
+        assert isinstance(path, str), 'Invalid input type: {}'.format(type(path))
+        self.set_download_dir(path)
 
 
     def clear(self):
@@ -143,7 +169,8 @@ class CacheManager:
         """Returns an empty (dummy) template of the cache data structure."""
         return {
             "info": {
-                "default_cache_dir": self.default_dir
+                "default_cache_dir": self.default_dir,
+                "default_download_dir": '',
             },
             "dataset": {},
             "category": {}

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import errno
 import json
+import warnings
 
 
 class CacheManager:
@@ -295,11 +296,26 @@ class CacheManager:
         self.write_data_cache(self.data)
 
 
-    def reset_cache(self):
-        """Resets all datasets/categories from cache."""
-        self.data['dataset'] = {}
-        self.data['category'] = {}
-        self.write_data_cache(self.data)
+    def reset_cache(self, force_reset=False):
+        """Resets all datasets/categories from cache.
+
+        Parameters
+        ----------
+        force_reset : bool, optional
+            Forces the cache to be reset (emptied) if True.
+
+        Warning
+        -------
+        UserWarning
+            If force_reset is False, display a warning to the user.
+        """
+        if force_reset:
+            self.write_data_cache(self._empty_data(), self.cache_filename)
+            self.reload_cache()
+        else:
+            msg = 'Warning: All information about stored datasets will be lost if you proceed!' \
+                  + 'Set \'force_reset=True\' to reset the dbcollection.json file.'
+            warnings.warn(msg, UserWarning, stacklevel=2)
 
 
     def check_dataset_name(self, name):
@@ -623,3 +639,4 @@ class CacheManager:
     def reload_cache(self):
         """Reload the cache file contents."""
         self.data = self.read_data_cache()
+        self._cache_dir = self._get_cache_dir()

--- a/dbcollection/core/config.py
+++ b/dbcollection/core/config.py
@@ -66,10 +66,10 @@ def config_cache(field=None, value=None, delete_cache=False, delete_cache_dir=Fa
 
     if delete_cache_dir:
         # delete cache dir
-        if os.path.exists(cache_manager.default_dir):
-            shutil.rmtree(cache_manager.default_dir)
+        if os.path.exists(cache_manager.cache_dir):
+            shutil.rmtree(cache_manager.cache_dir)
             if verbose:
-                print('Deleted {} directory.'.format(cache_manager.default_dir))
+                print('Deleted {} directory.'.format(cache_manager.cache_dir))
 
     if delete_cache_file:
         # delete the entire cache

--- a/dbcollection/core/config.py
+++ b/dbcollection/core/config.py
@@ -66,17 +66,17 @@ def config_cache(field=None, value=None, delete_cache=False, delete_cache_dir=Fa
 
     if delete_cache_dir:
         # delete cache dir
-        if os.path.exists(cache_manager.default_cache_dir):
-            shutil.rmtree(cache_manager.default_cache_dir)
+        if os.path.exists(cache_manager.default_dir):
+            shutil.rmtree(cache_manager.default_dir)
             if verbose:
-                print('Deleted {} directory.'.format(cache_manager.default_cache_dir))
+                print('Deleted {} directory.'.format(cache_manager.default_dir))
 
     if delete_cache_file:
         # delete the entire cache
-        if os.path.exists(cache_manager.cache_fname):
-            os.remove(cache_manager.cache_fname)
+        if os.path.exists(cache_manager.cache_filename):
+            os.remove(cache_manager.cache_filename)
             if verbose:
-                print('Deleted {} cache file.'.format(cache_manager.cache_fname))
+                print('Deleted {} cache file.'.format(cache_manager.cache_filename))
     else:
         if reset_cache:
             # reset the cache file

--- a/dbcollection/core/config.py
+++ b/dbcollection/core/config.py
@@ -80,7 +80,7 @@ def config_cache(field=None, value=None, delete_cache=False, delete_cache_dir=Fa
     else:
         if reset_cache:
             # reset the cache file
-            cache_manager.reset_cache()
+            cache_manager.reset_cache(force_reset=True)
         else:
             if not field is None:
                 if verbose:

--- a/dbcollection/core/download.py
+++ b/dbcollection/core/download.py
@@ -12,7 +12,7 @@ from dbcollection.core.cache import CacheManager
 def get_dirs(cache_manager, name, data_dir):
     """Parse data directory and cache save path."""
     if data_dir is None or data_dir is '':
-        data_dir_ = os.path.join(cache_manager.default_cache_dir, name, 'data')
+        data_dir_ = os.path.join(cache_manager.default_dir, name, 'data')
     else:
         #assert os.path.isdir(data_dir), 'Must insert a valid path: data_dir={}'.format(data_dir)
         if not os.path.exists(data_dir):
@@ -27,7 +27,7 @@ def get_dirs(cache_manager, name, data_dir):
     if not os.path.exists(data_dir_):
         os.makedirs(data_dir_)
 
-    cache_save_path = os.path.join(cache_manager.default_cache_dir, name)
+    cache_save_path = os.path.join(cache_manager.default_dir, name)
     if not os.path.exists(cache_save_path):
         os.makedirs(cache_save_path)
 

--- a/dbcollection/core/download.py
+++ b/dbcollection/core/download.py
@@ -12,7 +12,7 @@ from dbcollection.core.cache import CacheManager
 def get_dirs(cache_manager, name, data_dir):
     """Parse data directory and cache save path."""
     if data_dir is None or data_dir is '':
-        data_dir_ = os.path.join(cache_manager.default_dir, name, 'data')
+        data_dir_ = os.path.join(cache_manager.cache_dir, name, 'data')
     else:
         #assert os.path.isdir(data_dir), 'Must insert a valid path: data_dir={}'.format(data_dir)
         if not os.path.exists(data_dir):
@@ -27,7 +27,7 @@ def get_dirs(cache_manager, name, data_dir):
     if not os.path.exists(data_dir_):
         os.makedirs(data_dir_)
 
-    cache_save_path = os.path.join(cache_manager.default_dir, name)
+    cache_save_path = os.path.join(cache_manager.cache_dir, name)
     if not os.path.exists(cache_save_path):
         os.makedirs(cache_save_path)
 

--- a/dbcollection/core/load.py
+++ b/dbcollection/core/load.py
@@ -76,7 +76,7 @@ def load(name=None, task='default', data_dir=None, verbose=True, is_test=False):
     # get task cache file path
     if task=='' or task=='default':
         task = available_datasets_list[name]['default_task']
-    task_cache_path = cache_manager.get_cache_path(name, task)
+    task_cache_path = cache_manager.get_task_cache_path(name, task)
 
     # Create a loader
     dataset_loader = DataLoader(name, task, dset_paths['data_dir'], task_cache_path)

--- a/dbcollection/tests/core/test_api.py
+++ b/dbcollection/tests/core/test_api.py
@@ -102,7 +102,3 @@ def test_info_cache():
 def test_info_datasets():
     info_datasets(is_test=True)
     pass
-
-
-if __name__ == '__main__':
-    test_process('mnist', 'classification', None, True, True, True)

--- a/dbcollection/tests/core/test_cache.py
+++ b/dbcollection/tests/core/test_cache.py
@@ -40,43 +40,14 @@ data = {
     }
 }
 
-cache = CacheManager(is_test=True)
 
-def reset_cache_data():
-    data = {
-        "info": {
-            "default_cache_dir": os.path.join('some','path','dir')
-        },
-        "dataset": {
-            "test_dataset1": {
-                "cache_dir": os.path.join('some','path','dir','test_dataset1'),
-                "data_dir": os.path.join('some','path','dir','test_dataset1', 'data'),
-                "tasks": {
-                    "default": "file1.h5",
-                    "classification": "file2.h5",
-                    "extra": "file3.h5"
-                },
-                "keywords": ['image_processing', 'classification']
-            },
-            "test_dataset2": {
-                "cache_dir": os.path.join('some','path','dir','test_dataset2'),
-                "data_dir": os.path.join('some','path','dir','test_dataset2', 'data'),
-                "tasks": {
-                    "default": "file4.h5",
-                    "classification": "file5.h5",
-                    "extra": "file6.h5"
-                },
-                "keywords": ['image_processing', 'classification']
-            },
-        },
-        "category": {
-            'image_processing': ['test_dataset1, test_dataset2'],
-            'classification': ['test_dataset1, test_dataset2']
-        }
-    }
-    cache.data = data
-    cache.default_cache_dir = data["info"]["default_cache_dir"]
+@pytest.fixture
+def cache_manager():
+    cache = CacheManager(is_test=True)
+    cache.reset_cache(force_reset=True)  # clear old contents
     cache.write_data_cache(data)
+    cache.reload_cache()
+    return cache
 
 
 @pytest.mark.parametrize("name, new_info, is_append", [
@@ -84,11 +55,10 @@ def reset_cache_data():
     ('new_dataset2', {}, False),
     ('test_dataset1', {}, False),
 ])
-def test_add_data(name, new_info, is_append):
-    reset_cache_data()
-    cache.add_data(name, new_info, is_append)
-    assert(name in cache.data['dataset'])
-    assert(cache.data['dataset'][name] == new_info)
+def test_add_data(name, new_info, is_append, cache_manager):
+    cache_manager.add_data(name, new_info, is_append)
+    assert(name in cache_manager.data['dataset'])
+    assert(cache_manager.data['dataset'][name] == new_info)
 
 
 @pytest.mark.parametrize("name, delete_cache", [
@@ -96,19 +66,17 @@ def test_add_data(name, new_info, is_append):
     ('test_dataset2', False),
     ('test_dataset2', True),
 ])
-def test_delete_dataset(name, delete_cache):
-    reset_cache_data()
-    cache.delete_dataset(name, delete_cache)
-    assert(not name in cache.data['dataset'])
+def test_delete_dataset(name, delete_cache, cache_manager):
+    cache_manager.delete_dataset(name, delete_cache)
+    assert(not name in cache_manager.data['dataset'])
 
 
 @pytest.mark.parametrize("name, delete_cache", [
     ('test_dataset_non_exists', False),
 ])
-def test_delete_dataset_raise(name, delete_cache):
-    reset_cache_data()
+def test_delete_dataset_raise(name, delete_cache, cache_manager):
     with pytest.raises(Exception):
-        cache.delete_dataset(name, delete_cache)
+        cache_manager.delete_dataset(name, delete_cache)
 
 
 @pytest.mark.parametrize("name, output", [
@@ -117,9 +85,8 @@ def test_delete_dataset_raise(name, delete_cache):
     ('test_dataset_non_exists', False),
     ('', False),
 ])
-def test_exists_dataset(name, output):
-    reset_cache_data()
-    assert(output == cache.exists_dataset(name))
+def test_exists_dataset(name, output, cache_manager):
+    assert(output == cache_manager.exists_dataset(name))
 
 
 @pytest.mark.parametrize("name, task, output", [
@@ -130,9 +97,8 @@ def test_exists_dataset(name, output):
     ('test_dataset_non_exists', 'default', False),
     ('', 'default', False),
 ])
-def test_exists_task(name, task, output):
-    reset_cache_data()
-    assert(output == cache.exists_task(name, task))
+def test_exists_task(name, task, output, cache_manager):
+    assert(output == cache_manager.exists_task(name, task))
 
 
 @pytest.mark.parametrize("name, output", [
@@ -145,9 +111,8 @@ def test_exists_task(name, task, output):
         "cache_dir": data["dataset"]["test_dataset2"]["cache_dir"]
     }),
 ])
-def test_get_dataset_storage_paths(name, output):
-    reset_cache_data()
-    assert(output == cache.get_dataset_storage_paths(name))
+def test_get_dataset_storage_paths(name, output, cache_manager):
+    assert(output == cache_manager.get_dataset_storage_paths(name))
 
 
 @pytest.mark.parametrize("name, task", [
@@ -158,10 +123,9 @@ def test_get_dataset_storage_paths(name, output):
     ('test_dataset2', "classification"),
     ('test_dataset2', "extra"),
 ])
-def test_get_task_cache_path__succeed(name, task):
-    reset_cache_data()
-    task_path = cache.data["dataset"][name]["tasks"][task]
-    assert(task_path == cache.get_task_cache_path(name, task))
+def test_get_task_cache_path__succeed(name, task, cache_manager):
+    task_path = cache_manager.data["dataset"][name]["tasks"][task]
+    assert(task_path == cache_manager.get_task_cache_path(name, task))
 
 
 @pytest.mark.parametrize("name, task", [
@@ -172,35 +136,32 @@ def test_get_task_cache_path__succeed(name, task):
     ('test_dataset_non_exists', "classification"),
     ('test_dataset_non_exists', "extra"),
 ])
-def test_get_task_cache_path__fail(name, task):
-    reset_cache_data()
+def test_get_task_cache_path__fail(name, task, cache_manager):
     with pytest.raises(Exception):
-        cache.get_task_cache_path(name, task)
+        cache_manager.get_task_cache_path(name, task)
 
 @pytest.mark.parametrize("name, keywords", [
     ('test_dataset1', "new_kw"),
     ('test_dataset1', ["new_kw1", "new_kw2"]),
 ])
-def test_add_keywords(name, keywords):
-    reset_cache_data()
-    cache.add_keywords(name, keywords)
+def test_add_keywords(name, keywords, cache_manager):
+    cache_manager.add_keywords(name, keywords)
     if not isinstance(keywords, list):
         keywords = [keywords]
-    l = [kw for kw in keywords if kw in cache.data["dataset"][name]["keywords"]]
+    l = [kw for kw in keywords if kw in cache_manager.data["dataset"][name]["keywords"]]
     assert(any(l))
-    l = [kw for kw in keywords if kw in cache.data["category"]]
+    l = [kw for kw in keywords if kw in cache_manager.data["category"]]
     assert(any(l))
 
 @pytest.mark.parametrize("name, keywords", [
     ('test_dataset1', ""),
     ('test_dataset1', ["", ""]),
 ])
-def test_add_keywords_empty(name, keywords):
-    reset_cache_data()
-    kw = list(cache.data["dataset"][name]["keywords"])
-    cache.add_keywords(name, keywords)
-    assert(set(kw) == set(cache.data["dataset"][name]["keywords"]))
-    l = [kw for kw in keywords if kw in cache.data["category"]]
+def test_add_keywords_empty(name, keywords, cache_manager):
+    kw = list(cache_manager.data["dataset"][name]["keywords"])
+    cache_manager.add_keywords(name, keywords)
+    assert(set(kw) == set(cache_manager.data["dataset"][name]["keywords"]))
+    l = [kw for kw in keywords if kw in cache_manager.data["category"]]
     assert(not any(l))
 
 
@@ -210,17 +171,16 @@ def test_add_keywords_empty(name, keywords):
     ('test_dataset2', os.path.join('new', 'data', 'dir'), {"new_task": "new_file.h5"},
      ["new_kw1", "new_kw2"], True),
 ])
-def test_update(name, data_dir, cache_tasks, cache_keywords, is_append):
-    reset_cache_data()
-    cache.update(name, data_dir, cache_tasks, cache_keywords, is_append)
-    assert(name in cache.data["dataset"])
+def test_update(name, data_dir, cache_tasks, cache_keywords, is_append, cache_manager):
+    cache_manager.update(name, data_dir, cache_tasks, cache_keywords, is_append)
+    assert(name in cache_manager.data["dataset"])
     if is_append:
-        assert(data_dir != cache.data["dataset"][name]["data_dir"])
+        assert(data_dir != cache_manager.data["dataset"][name]["data_dir"])
     else:
-        assert(data_dir == cache.data["dataset"][name]["data_dir"])
-    l = [task for task in cache_tasks if task in cache.data["dataset"][name]["tasks"]]
+        assert(data_dir == cache_manager.data["dataset"][name]["data_dir"])
+    l = [task for task in cache_tasks if task in cache_manager.data["dataset"][name]["tasks"]]
     assert(any(l))
-    l = [kw for kw in cache_keywords if kw in cache.data["dataset"][name]["keywords"]]
+    l = [kw for kw in cache_keywords if kw in cache_manager.data["dataset"][name]["keywords"]]
     assert(any(l))
 
 
@@ -230,10 +190,9 @@ def test_update(name, data_dir, cache_tasks, cache_keywords, is_append):
     ('test_dataset2', 1),
     ('test_dataset2', {'new': 'stuff'}),
 ])
-def test_modify_field_dataset(field, value):
-    reset_cache_data()
-    cache.modify_field(field, value)
-    assert(value == cache.data["dataset"][field])
+def test_modify_field_dataset(field, value, cache_manager):
+    cache_manager.modify_field(field, value)
+    assert(value == cache_manager.data["dataset"][field])
 
 
 @pytest.mark.parametrize("field, value", [
@@ -242,20 +201,18 @@ def test_modify_field_dataset(field, value):
     ('image_processing', ["new_val1", "new_val2"]),
     ('classification', 1),
 ])
-def test_modify_field_dataset_keywords(field, value):
-    reset_cache_data()
-    cache.modify_field(field, value)
-    assert(value == cache.data["category"][field])
+def test_modify_field_dataset_keywords(field, value, cache_manager):
+    cache_manager.modify_field(field, value)
+    assert(value == cache_manager.data["category"][field])
 
 
 @pytest.mark.parametrize("field, value", [
     ('default_cache_dir', "new_val"),
     ('default_cache_dir', ["new_val1", "new_val2"]),
 ])
-def test_modify_field_info(field, value):
-    reset_cache_data()
-    cache.modify_field(field, value)
-    assert(value == cache.data["info"][field])
+def test_modify_field_info(field, value, cache_manager):
+    cache_manager.modify_field(field, value)
+    assert(value == cache_manager.data["info"][field])
 
 
 @pytest.mark.parametrize("field, value", [
@@ -269,7 +226,6 @@ def test_modify_field_info(field, value):
     ('info2', "new_val"),
     ('default_cache_dir_', "new_val"),
 ])
-def test_modify_field_raise(field, value):
-    reset_cache_data()
+def test_modify_field_raise(field, value, cache_manager):
     with pytest.raises(Exception):
-        cache.modify_field(field, value)
+        cache_manager.modify_field(field, value)

--- a/dbcollection/tests/core/test_cache.py
+++ b/dbcollection/tests/core/test_cache.py
@@ -158,10 +158,10 @@ def test_get_dataset_storage_paths(name, output):
     ('test_dataset2', "classification"),
     ('test_dataset2', "extra"),
 ])
-def test_get_cache_path__succeed(name, task):
+def test_get_task_cache_path__succeed(name, task):
     reset_cache_data()
     task_path = cache.data["dataset"][name]["tasks"][task]
-    assert(task_path == cache.get_cache_path(name, task))
+    assert(task_path == cache.get_task_cache_path(name, task))
 
 
 @pytest.mark.parametrize("name, task", [
@@ -172,10 +172,10 @@ def test_get_cache_path__succeed(name, task):
     ('test_dataset_non_exists', "classification"),
     ('test_dataset_non_exists', "extra"),
 ])
-def test_get_cache_path__fail(name, task):
+def test_get_task_cache_path__fail(name, task):
     reset_cache_data()
     with pytest.raises(Exception):
-        cache.get_cache_path(name, task)
+        cache.get_task_cache_path(name, task)
 
 @pytest.mark.parametrize("name, keywords", [
     ('test_dataset1', "new_kw"),


### PR DESCRIPTION
This pr adds the following changes:
- new method  `reload_cache()` to reload the cache contents 
- rename `default_data_dir` to `data_dir`and add a getter and setter methods
- new field `download_dir`
- rename field `cache_fname` to `cache_filename`
- some code refactoring
