### PR TITLE
Feature add data allocation to memory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,6 @@ environment:
       PY_TAG: "cp35"
 
     - CONDA_ROOT: "C:\\Miniconda3_64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "34"
-      CONDA_NPY: "112"
-      PLAT_NAME: "win-amd64"
-      PY_TAG: "cp34"
-
-    - CONDA_ROOT: "C:\\Miniconda3_64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -31,6 +31,7 @@ class CacheManager:
         Default save dir path for downloaded data.
     data : dict
         Cache contents.
+
     """
 
     def __init__(self, is_test=False):
@@ -119,6 +120,7 @@ class CacheManager:
         ------
         IOError
             If the file cannot be opened.
+
         """
         try:
             with open(self.cache_filename, 'r') as json_data:
@@ -133,6 +135,7 @@ class CacheManager:
         -------
         dict
             Data structure of the cache (file).
+
         """
         # check if file exists
         if os.path.exists(self.cache_filename):
@@ -183,12 +186,13 @@ class CacheManager:
         Raises
         ------
         OSError
-            If the file does not exist.
+            If an error occurred when deleting a file.
+
         """
         try:
             if os.path.exists(fname):
                 if os.path.isdir(fname):
-                    shutil.rmtree(fname, ignore_errors=True)
+                    shutil.rmtree(fname)
                 else:
                     os.remove(fname)
         except OSError as err:
@@ -202,6 +206,7 @@ class CacheManager:
         ----------
         name : str
             Dataset name.
+
         """
         try:
             self.data['dataset'].pop(name)
@@ -221,6 +226,7 @@ class CacheManager:
         ----------
         name : str
             Name of the dataset.
+
         """
         keywords = []
         for keyword in self.data['category']:
@@ -246,12 +252,17 @@ class CacheManager:
             Name of the dataset.
         task : str
             Name of the task
+
         """
         try:
+            task_filename = self.data['dataset'][name]['tasks'][task]
             self.data['dataset'][name]['tasks'].pop(task)
 
             # update cache file on disk
             self.write_data_cache(self.data)
+
+            # remove file from disk
+            self._os_remove(task_filename)
 
             return True
         except KeyError:
@@ -265,6 +276,7 @@ class CacheManager:
         ----------
         name : str
             Name of the dataset.
+
         """
         # get cache dir path
         cache_dir_path = os.path.join(self._cache_dir, name)
@@ -293,6 +305,7 @@ class CacheManager:
         -------
         UserWarning
             If force_reset is False, display a warning to the user.
+
         """
         if force_reset:
             self.write_data_cache(self._empty_data(), self.cache_filename)
@@ -314,6 +327,7 @@ class CacheManager:
         -------
         bool
             The dataset exists (True) or not (False).
+
         """
         return name in self.data['dataset'].keys()
 
@@ -328,6 +342,7 @@ class CacheManager:
             New data.
         is_append : bool, optional
             Appends the task cache data to existing ones.
+
         """
         if is_append:
             if name in self.data['dataset']:
@@ -346,6 +361,7 @@ class CacheManager:
             Name of the dataset.
         delete_data : bool, optional
             Flag indicating if the data's directory has to be deleted (or skip it).
+
         """
         dset_paths = self.get_dataset_storage_paths(name)
 
@@ -372,6 +388,7 @@ class CacheManager:
         -------
         bool
             Return true if the category exists, else return False.
+
         """
         return name in self.data['dataset']
 
@@ -389,6 +406,7 @@ class CacheManager:
         -------
         bool
             Return true if the task exists, else return False.
+
         """
         try:
             return task in self.data['dataset'][name]['tasks']
@@ -412,6 +430,7 @@ class CacheManager:
         ------
         KeyError
             If the dataset name does not exist in cache.
+
         """
         try:
             return {
@@ -439,7 +458,8 @@ class CacheManager:
         Raises
         ------
         KeyError
-            In case the dataset name
+            In case the dataset name.
+
         """
         try:
             return self.data['dataset'][name]['tasks'][task]
@@ -456,6 +476,7 @@ class CacheManager:
             Name of the dataset.
         keywords : list
             Keyword categories of the dataset.
+
         """
         if isinstance(keywords, list):
             keywords = tuple(keywords)
@@ -488,6 +509,7 @@ class CacheManager:
             A list of keywords caracterizing the dataset.
         is_append : bool
             Overrides existing cache info data with new data.
+
         """
         new_info_dict = {
             "data_dir": data_dir,
@@ -527,6 +549,7 @@ class CacheManager:
         ------
         Exception
             If the input field is not valid.
+
         """
         assert field, 'Invalid field: {}'.format(field)
         assert value, 'Invalid value: {}'.format(value)
@@ -570,6 +593,7 @@ class CacheManager:
             Displays the dataset contents.
         show_categories : bool, optional
             Displays the categories information.
+
         """
         # print info header
         if show_paths:

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -63,6 +63,8 @@ class CacheManager:
         """Get the default cache dir path."""
         return self.data['info']['default_cache_dir']
 
+    cache_dir = property(_get_cache_dir, _set_cache_dir)
+
     def _default_cache_dir_path(self):
         """Returns the pre-defined path of the cache_dir."""
         if self.is_test:
@@ -74,8 +76,6 @@ class CacheManager:
     def reset_cache_dir(self):
         """Reset the default download dir."""
         self._set_cache_dir(self._default_cache_dir_path())
-
-    cache_dir = property(_get_cache_dir, _set_cache_dir)
 
     def create_os_home_dir(self):
         """Create the main dir to store all metadata files."""

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -157,6 +157,7 @@ class CacheManager:
         ------
         IOError
             If the file cannot be opened.
+
         """
         filename = fname or self.cache_filename
         with open(filename, 'w') as file_cache:

--- a/dbcollection/core/loader.py
+++ b/dbcollection/core/loader.py
@@ -142,7 +142,15 @@ class FieldLoader(object):
         self._in_memory = is_in_memory
 
     def _get_to_memory(self):
-        """Modifies how data is accessed and stored. If True, allocates data to memory. Otherwise, keeps it in disk."""
+        """Modifies how data is accessed and stored.
+
+        Accessing data from a field can be done in two ways: memory or disk.
+        To enable data allocation and access from memory requires the user to
+        specify a boolean. If set to True, data is allocated to a numpy ndarray
+        and all accesses are done in memory. Otherwise, data is kept in disk and
+        accesses are done using the HDF5 object handler.
+
+        """
         return self._in_memory
 
     to_memory = property(_get_to_memory, _set_to_memory)

--- a/dbcollection/core/loader.py
+++ b/dbcollection/core/loader.py
@@ -42,6 +42,8 @@ class FieldLoader(object):
         """Initialize class."""
         assert hdf5_field, 'Must input a valid hdf5 dataset.'
         self.data = hdf5_field
+        self.hdf5_handler = hdf5_field
+        self._in_memory = False
         s = hdf5_field.name.split('/')
         self.set = s[1]
         self.name = s[-1]
@@ -89,6 +91,7 @@ class FieldLoader(object):
         -------
         list
             Returns the size of the field.
+
         """
         return self.shape
 
@@ -102,6 +105,7 @@ class FieldLoader(object):
         -------
         int
             Index of the field in the 'object_ids' list.
+
         """
         return self.obj_id
 
@@ -109,6 +113,7 @@ class FieldLoader(object):
         """Prints information about the field.
 
         Displays information like name, size and shape of the field.
+
         """
         if hasattr(self, 'obj_id'):
             print('Field: {},  shape = {},  dtype = {},  (in \'object_ids\', position = {})'
@@ -116,6 +121,28 @@ class FieldLoader(object):
         else:
             print('Field: {},  shape = {},  dtype = {}'
                   .format(self.name, str(self.shape), str(self.type)))
+
+    def _set_to_memory(self, is_in_memory):
+        """"Stores the contents of the field in a numpy array if True.
+
+        Parameters
+        ----------
+        is_in_memory : bool
+            Move the data to memory (if True).
+
+        """
+        assert isinstance(is_in_memory, bool), 'Invalid input. Must insert a boolean type.'
+        if is_in_memory:
+            self.data = self.hdf5_handler.value
+        else:
+            self.data = self.hdf5_handler
+        self._in_memory = is_in_memory
+
+    def _get_to_memory(self):
+        """Modifies how data is accessed and stored. If True, allocates data to memory. Otherwise, keeps it in disk."""
+        return self._in_memory
+
+    to_memory = property(_get_to_memory, _set_to_memory)
 
     def __getitem__(self, index):
         """
@@ -127,7 +154,8 @@ class FieldLoader(object):
         Returns
         -------
         np.ndarray
-            Numpy data array
+            Numpy data array.
+
         """
         return self.data[index]
 
@@ -137,6 +165,7 @@ class FieldLoader(object):
         -------
         int
             Number of samples
+
         """
         return self.shape[0]
 
@@ -213,6 +242,7 @@ class SetLoader(object):
             Numpy array containing the field's data.
         list
             List of numpy arrays if using a list of indexes.
+
         """
         assert field, 'Must input a valid field name: {}'.format(field)
         assert field in self.fields, 'Field \'{}\' does not exist in the \'{}\' set.' \
@@ -241,6 +271,7 @@ class SetLoader(object):
         -------
         str/int/list
             Value/list of a field from the metadata cache file.
+
         """
         if isinstance(idx, list) or isinstance(idx, tuple):
             assert min(idx) >= 0, 'list/tuple must have indexes >= 0: {}'.format(idx)
@@ -300,6 +331,7 @@ class SetLoader(object):
         list
             Returns a list of indexes or, if convert_to_value is True,
             a list of data arrays/values.
+
         """
         if idx is None:
             idx = tuple(range(0, self.nelems))
@@ -331,6 +363,7 @@ class SetLoader(object):
         -------
         list
             Returns the size of a field.
+
         """
         assert field in self.fields, 'Field \'{}\' does not exist in the \'{}\' set.' \
                                      .format(field, self.set)
@@ -343,6 +376,7 @@ class SetLoader(object):
         -------
         list
             List of all data fields of the dataset.
+
         """
         return self.fields
 
@@ -361,6 +395,7 @@ class SetLoader(object):
         -------
         int
             Index of the field in the 'object_ids' list.
+
         """
         assert field, 'Must input a valid field: {}'.format(field)
         if field in self._object_fields:
@@ -377,6 +412,7 @@ class SetLoader(object):
 
         This method provides the necessary information about a data set
         internals to help determine how to use/handle a specific field.
+
         """
         print('\n> Set: {}'.format(self.set))
 
@@ -439,6 +475,7 @@ class SetLoader(object):
         -------
         int
             Number of elements
+
         """
         return self.nelems
 
@@ -540,6 +577,7 @@ class DataLoader(object):
             Numpy array containing the field's data.
         list
             List of numpy arrays if using a list of indexes.
+
         """
         assert set_name, 'Must input a valid set name: {}'.format(set_name)
         assert set_name in self.sets, 'Set {} does not exist for this dataset.' \
@@ -598,6 +636,7 @@ class DataLoader(object):
         -------
         list
             Returns the size of a field.
+
         """
         if set_name is None:
             out = {}
@@ -623,6 +662,7 @@ class DataLoader(object):
         -------
         list
             List of all data fields of the dataset.
+
         """
         if set_name:
             assert set_name in self.sets, 'Set {} does not exist for this dataset.' \
@@ -653,6 +693,7 @@ class DataLoader(object):
         -------
         int
             Index of the field in the 'object_ids' list.
+
         """
         assert set_name, 'Must input a valid set name: {}'.format(set_name)
         assert set_name in self.sets, 'Set {} does not exist for this dataset.' \
@@ -680,6 +721,7 @@ class DataLoader(object):
         ----------
         set_name : str, optional
             Name of the set.
+
         """
         if set_name:
             assert set_name in self.sets, 'Set {} does not exist for this dataset.' \

--- a/dbcollection/core/loader.py
+++ b/dbcollection/core/loader.py
@@ -76,10 +76,13 @@ class FieldLoader(object):
             List of numpy arrays if using a list of indexes.
 
         """
-        if idx:
-            data = self.data[idx]
+        if idx is None:
+            if self._in_memory:
+                data = self.data
+            else:
+                data = self.data.value
         else:
-            data = self.data.value
+            data = self.data[idx]
         return data
 
     def size(self):

--- a/dbcollection/tests/core/test_cache.py
+++ b/dbcollection/tests/core/test_cache.py
@@ -78,6 +78,12 @@ def test_delete_dataset_raise(name, delete_cache, cache_manager):
     with pytest.raises(Exception):
         cache_manager.delete_dataset(name, delete_cache)
 
+@pytest.mark.parametrize("name, task", [
+    ('test_dataset2', 'extra'),
+])
+def test_delete_task(name, task, cache_manager):
+    cache_manager.delete_task(name, task)
+
 
 @pytest.mark.parametrize("name, output", [
     ('test_dataset1', True),

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -17,7 +17,7 @@ API methods
 .. autofunction:: dbcollection.core.api.query
 .. autofunction:: dbcollection.core.api.info_cache
 .. autofunction:: dbcollection.core.api.info_datasets
-.. autofunction:: dbcollection.core.db.fetch_list_datasets
+.. autofunction:: dbcollection.core.api.fetch_list_datasets
 
 Cache management
 --------------------------------


### PR DESCRIPTION
This PR addresses #48 by adding the `.to_memory` field to the `FieldLoader` class. This field is a boolean indicating if the data referenced and stored in the `HDF5` metadata file is allocated in memory in a numpy `ndarray` (`True` - move to RAM, `False` - keep it in disk). This allows users to explicitly define if a variable should be stored and accessed from memory or from disk.