### PR TITLE
Fix query() API method

### DIFF
--- a/dbcollection/core/api.py
+++ b/dbcollection/core/api.py
@@ -567,7 +567,7 @@ def query(pattern='info', is_test=False):
         })
     for category in cache_manager.data['category']:
         if pattern in cache_manager.data['category'][category]:
-            query_list.append({'category': {category: [pattern,]}})
+            query_list.append({'category': {category: [pattern, ]}})
 
     return query_list
 

--- a/dbcollection/core/api.py
+++ b/dbcollection/core/api.py
@@ -508,35 +508,66 @@ def query(pattern='info', is_test=False):
         Flag used for tests.
 
     """
+    assert isinstance(pattern, str), 'Must insert a string value as input. ' + \
+                                     'Expected "str", got "{}"'.format(pattern)
     # Load a cache manager object
     cache_manager = CacheManager(is_test)
 
     # init list
-    query_list = {}
+    query_list = []
 
     # check info / dataset lists first
     if pattern in cache_manager.data:
-        query_list.update({pattern: cache_manager.data[pattern]})
+        query_list.append({pattern: cache_manager.data[pattern]})
 
     # match default paths
     if pattern in cache_manager.data['info']:
-        query_list.update({pattern: cache_manager.data['info'][pattern]})
+        query_list.append({'info': {pattern: cache_manager.data['info'][pattern]}})
 
     # match datasets/tasks
     if pattern in cache_manager.data['dataset']:
-        query_list.update({pattern: cache_manager.data['dataset'][pattern]})
-
-    # match datasets/tasks
-    if pattern in cache_manager.data['category']:
-        query_list.update({pattern: list(cache_manager.data['category'][pattern].keys())})
+        query_list.append({'dataset': {pattern: cache_manager.data['dataset'][pattern]}})
 
     for name in cache_manager.data['dataset']:
         if pattern in cache_manager.data['dataset'][name]:
-            query_list.update({pattern: cache_manager.data['dataset'][name][pattern]})
+            query_list.append({
+                'dataset': {
+                    name: {
+                        pattern: cache_manager.data['dataset'][name][pattern]
+                    }
+                }
+            })
         if pattern in cache_manager.data['dataset'][name]['tasks']:
-            query_list.update({pattern: cache_manager.data['dataset'][name]['tasks'][pattern]})
+            query_list.append({
+                'dataset': {
+                    name: {
+                        'tasks': {
+                            pattern: cache_manager.data['dataset'][name]['tasks'][pattern]
+                        }
+                    }
+                }
+            })
         if pattern in cache_manager.data['dataset'][name]['keywords']:
-            query_list.update({pattern: cache_manager.data['dataset'][name]['keywords'][pattern]})
+            query_list.append({
+                'dataset': {
+                    name: {
+                        'keywords': {
+                            pattern: cache_manager.data['dataset'][name]['keywords']
+                        }
+                    }
+                }
+            })
+
+    # match category
+    if pattern in cache_manager.data['category']:
+        query_list.append({
+            'category': {
+                pattern: list(cache_manager.data['category'][pattern])
+            }
+        })
+    for category in cache_manager.data['category']:
+        if pattern in cache_manager.data['category'][category]:
+            query_list.append({'category': {category: [pattern,]}})
 
     return query_list
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 skipsdist = true
-envlist = py{27,34,35,36},urls_check
+envlist = py{27,34,35,36},urls_check,flake8
 
 [testenv]
 commands =
@@ -23,3 +23,9 @@ commands =
     pip install pytest pytest-cov
     python setup.py install
     pytest --cov=dbcollection {toxinidir}/dbcollection/tests/datasets/__test_check_urls.py
+
+[testenv:flake8]
+basepython = python3.6
+commands =
+    pip install flake8
+    flake8


### PR DESCRIPTION
This PR addresses #70 and modifies how the `query()` method fetches patterns from the cache.