### PR TITLE
Remove db name requirement from the data files' path

### DIFF
--- a/dbcollection/core/api.py
+++ b/dbcollection/core/api.py
@@ -72,18 +72,15 @@ def fetch_list_datasets():
 def get_dirs(cache_manager, name, data_dir):
     """Parse data directory and cache save path."""
     if data_dir is None or data_dir is '':
-        data_dir_ = os.path.join(cache_manager.download_dir, name, 'data')
+        data_dir_ = os.path.join(cache_manager.download_dir, name)
     else:
         if not os.path.exists(data_dir):
-            print('Creating save directory in disk: ' + data_dir)
-            os.makedirs(data_dir)
-
-        if os.path.split(data_dir)[1] == name:
-            data_dir_ = data_dir
-        else:
             data_dir_ = os.path.join(data_dir, name)
+        else:
+            data_dir_ = data_dir
 
     if not os.path.exists(data_dir_):
+        print('Creating save directory in disk: ' + data_dir_)
         os.makedirs(data_dir_)
 
     cache_save_path = os.path.join(cache_manager.cache_dir, name)
@@ -273,7 +270,7 @@ def load(name=None, task='default', data_dir=None, verbose=True, is_test=False):
 
     >>> import dbcollection as dbc
     >>> mnist = dbc.load('mnist')
-    >>> print('Dataset name: ', mnist.name)
+    >>> print('Dataset name: ', mnist.db_name)
     Dataset name:  mnist
 
     """
@@ -293,12 +290,12 @@ def load(name=None, task='default', data_dir=None, verbose=True, is_test=False):
     # check if dataset exists. If not attempt to download the dataset
     if not cache_manager.exists_dataset(name):
         download(name, data_dir, True, verbose, is_test)
-        cache_manager = CacheManager(is_test)  # reopen the cache file
+        cache_manager.reload_cache()  # reload the cache's data
 
     # check if the task exists inf cache
     if not cache_manager.exists_task(name, task):
         process(name, task, verbose, is_test)
-        cache_manager = CacheManager(is_test)  # reopen the cache file
+        cache_manager.reload_cache()  # reload the cache's
 
     # get data + cache dir paths
     dset_paths = cache_manager.get_dataset_storage_paths(name)

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -74,7 +74,7 @@ class CacheManager:
         return default_cache_dir
 
     def reset_cache_dir(self):
-        """Reset the default download dir."""
+        """Reset the default cache directory path."""
         self._set_cache_dir(self._default_cache_dir_path())
 
     def create_os_home_dir(self):
@@ -144,7 +144,7 @@ class CacheManager:
             return self._empty_data()
 
     def write_data_cache(self, data, fname=None):
-        """Write data to the dbcollection cache file.
+        """Write data to the cache file (dbcollection.json).
 
         Parameters
         ----------
@@ -162,6 +162,7 @@ class CacheManager:
         filename = fname or self.cache_filename
         with open(filename, 'w') as file_cache:
             json.dump(data, file_cache, sort_keys=True, indent=4, ensure_ascii=False)
+        self.reload_cache()  # reload the data
 
     def _empty_data(self):
         """Returns an empty (dummy) template of the cache data structure."""
@@ -310,7 +311,6 @@ class CacheManager:
         """
         if force_reset:
             self.write_data_cache(self._empty_data(), self.cache_filename)
-            self.reload_cache()
         else:
             msg = 'All information about stored datasets will be lost if you proceed! ' + \
                   'Set \'force_reset=True\' to proceed with the reset of dbcollection.json.'
@@ -496,7 +496,7 @@ class CacheManager:
                     self.data['category'][keyword] = [name]
 
     def update(self, name, data_dir, cache_tasks, cache_keywords, is_append=True):
-        """Update the cache file with new/updated data for a dataset.
+        """Modify/add data of a dataset in the cache file.
 
         Parameters
         ----------

--- a/dbcollection/utils/test.py
+++ b/dbcollection/utils/test.py
@@ -67,7 +67,7 @@ class TestBaseDB:
         print('Dataset: ' + loader.db_name)
         print('Task: ' + loader.task)
         print('Data path: ' + loader.data_dir)
-        print('Metadata cache path: ' + loader.cache_path)
+        print('Metadata cache path: ' + loader.hdf5_filepath)
 
     def load(self):
         """Return a data loader object for a dataset.


### PR DESCRIPTION
This PR addresses #72 and removes the need to have the same name of the dataset at the end of the path of the directory where data files are stored.

Also, some docstrings are rectified and an incorrect name of an attribute in `TestBaseDB` is  fixed.