### PR TITLE
[Feature request #86] Add arg to convert the output data into a string for get()

### DIFF
--- a/dbcollection/core/loader.py
+++ b/dbcollection/core/loader.py
@@ -65,7 +65,7 @@ class FieldLoader(object):
     def _get_hdf5_object_str(self):
         return self.hdf5_handler.name.split('/')
 
-    def get(self, index=None):
+    def get(self, index=None, convert_to_str=False):
         """Retrieves data of the field from the dataset's hdf5 metadata file.
 
         This method retrieves the i'th data from the hdf5 file. Also, it is
@@ -77,11 +77,16 @@ class FieldLoader(object):
         index : int/list/tuple, optional
             Index number of he field. If it is a list, returns the data
             for all the value indexes of that list.
+        convert_to_str : bool, optional
+            Convert the output data into a string.
+            Warning: output must be of type np.uint8
 
         Returns
         -------
-        np.ndarray
+        np.ndarray/list/str
             Numpy array containing the field's data.
+            If convert_to_str is set to True, it returns a string
+            or list of strings.
 
         Note
         ----
@@ -92,9 +97,12 @@ class FieldLoader(object):
 
         """
         if index is None:
-            return self._get_all_idx()
+            data = self._get_all_idx()
         else:
-            return self._get_range_idx(index)
+            data = self._get_range_idx(index)
+        if convert_to_str:
+            data = convert_ascii_to_str(data)
+        return data
 
     def _get_all_idx(self):
         """Return the full data array."""
@@ -302,7 +310,7 @@ class SetLoader(object):
         else:
             return None
 
-    def get(self, field, index=None):
+    def get(self, field, index=None, convert_to_str=False):
         """Retrieves data from the dataset's hdf5 metadata file.
 
         This method retrieves the i'th data from the hdf5 file with the
@@ -316,11 +324,16 @@ class SetLoader(object):
         index : int/list/tuple, optional
             Index number of the field. If it is a list, returns the data
             for all the value indexes of that list.
+        convert_to_str : bool, optional
+            Convert the output data into a string.
+            Warning: output must be of type np.uint8
 
         Returns
         -------
-        np.ndarray
+        np.ndarray/list/str
             Numpy array containing the field's data.
+            If convert_to_str is set to True, it returns a string
+            or list of strings.
 
         Raises
         ------
@@ -330,7 +343,7 @@ class SetLoader(object):
         """
         assert field, 'Must input a valid field name.'
         try:
-            return self.fields[field].get(index=index)
+            return self.fields[field].get(index=index, convert_to_str=convert_to_str)
         except KeyError:
             raise KeyError('\'{}\' does not exist in the \'{}\' set.'.format(field, self.set))
 
@@ -655,7 +668,7 @@ class DataLoader(object):
             sets[set_name] = SetLoader(self.hdf5_file[set_name])
         return sets
 
-    def get(self, set_name, field, index=None):
+    def get(self, set_name, field, index=None, convert_to_str=False):
         """Retrieves data from the dataset's hdf5 metadata file.
 
         This method retrieves the i'th data from the hdf5 file with the
@@ -671,11 +684,16 @@ class DataLoader(object):
         idx : int/list/tuple, optional
             Index number of the field. If it is a list, returns the data
             for all the value indexes of that list.
+        convert_to_str : bool, optional
+            Convert the output data into a string.
+            Warning: output must be of type np.uint8
 
         Returns
         -------
-        np.ndarray
+        np.ndarray/list/str
             Numpy array containing the field's data.
+            If convert_to_str is set to True, it returns a string
+            or list of strings.
 
         Raises
         ------
@@ -686,7 +704,7 @@ class DataLoader(object):
         assert set_name, 'Must input a set name.'
         assert field, 'Must input a field name.'
         try:
-            return self.sets[set_name].get(field, index)
+            return self.sets[set_name].get(field, index, convert_to_str=convert_to_str)
         except KeyError:
             self._raise_error_invalid_set_name(set_name)
 

--- a/dbcollection/tests/core/test_loader.py
+++ b/dbcollection/tests/core/test_loader.py
@@ -147,6 +147,48 @@ def test_FieldLoader_get_single_obj_empty_list_in_memory():
 
     assert np.array_equal(data, set_data['data'])
 
+@pytest.mark.parametrize("idx", [0, 1, 2, 3, 4])
+def test_FieldLoader_get_single_obj_convert_to_string(idx):
+    data_field = 'strings_list'
+    field_loader, set_data = db_generator.get_test_data_FieldLoader('train', data_field)
+
+    data = field_loader.get(idx, convert_to_str=True)
+
+    assert np.array_equal(data, ascii_to_str(set_data[data_field][idx]))
+    assert isinstance(data, str)
+
+@pytest.mark.parametrize("idx", [0, 1, 2, 3, 4])
+def test_FieldLoader_get_single_obj_convert_to_string_in_memory(idx):
+    data_field = 'strings_list'
+    field_loader, set_data = db_generator.get_test_data_FieldLoader('train', data_field)
+
+    field_loader.to_memory = True
+    data = field_loader.get(idx, convert_to_str=True)
+
+    assert np.array_equal(data, ascii_to_str(set_data[data_field][idx]))
+    assert isinstance(data, str)
+
+def test_FieldLoader_get_multi_obj_convert_to_string():
+    data_field = 'strings_list'
+    field_loader, set_data = db_generator.get_test_data_FieldLoader('train', data_field)
+
+    idx = list(range(3))
+    data = field_loader.get(idx, convert_to_str=True)
+
+    assert np.array_equal(data, ascii_to_str(set_data[data_field][idx]))
+    assert isinstance(data, list)
+
+def test_FieldLoader_get_multi_obj_convert_to_string_in_memory():
+    data_field = 'strings_list'
+    field_loader, set_data = db_generator.get_test_data_FieldLoader('train', data_field)
+
+    field_loader.to_memory = True
+    idx = list(range(3))
+    data = field_loader.get(idx, convert_to_str=True)
+
+    assert np.array_equal(data, ascii_to_str(set_data[data_field][idx]))
+    assert isinstance(data, list)
+
 def test_FieldLoader_get_two_obj():
     field_loader, set_data = db_generator.get_test_data_FieldLoader('train')
 

--- a/dbcollection/utils/test.py
+++ b/dbcollection/utils/test.py
@@ -218,6 +218,7 @@ class TestDatasetGenerator:
         }
 
         fields = {
+            "strings_list": lambda x: str_to_ascii(self.generate_string_list(x)),
             "data": lambda x: np.random.randint(0, 10, (x, 10)),
             "number": lambda x: np.array(range(x)),
             "field_with_a_long_name_for_printing": lambda x: np.array(range(x)),
@@ -235,6 +236,12 @@ class TestDatasetGenerator:
             data_fields[set_name] = sorted(dataset[set_name].keys())
 
         return dataset, data_fields
+
+    def generate_string_list(self, n):
+        """Generate a list of strings."""
+        template_str = 'string_'
+        string_list = [template_str + str(i) for i in range(n)]
+        return string_list
 
     def populate_set(self, size, fields, lists):
         dataset = {}
@@ -261,9 +268,9 @@ class TestDatasetGenerator:
     def load_hdf5_file(self):
         return h5py.File(self.hdf5_filepath, 'r')
 
-    def get_test_data_FieldLoader(self, set_name='train'):
+    def get_test_data_FieldLoader(self, set_name='train', field='data'):
         """Load data for testing the FieldLoader class."""
-        path = "/{}/data".format(set_name)
+        path = "/{set_name}/{field}".format(set_name=set_name, field=field)
         field_loader = self.load_hdf5_file_FieldLoader(path)
         set_data = self.dataset[set_name]
         return field_loader, set_data


### PR DESCRIPTION
This PR implements the feature request in #86 and adds the input argument `convert_to_string` to signal the `get()` methods to convert the output data retrieved from the `hdf5` file or memory into a string before returning the result.