### PR TITLE
[Fix] core api download() method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 .PHONY: test-api
 test-api:
 	make build
-	pipenv run pytest -v dbcollection/tests/core/test_api.py
+	pipenv run pytest -v dbcollection/tests/core/api/
 
 .PHONY: test-cache
 test-cache:

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -134,14 +134,17 @@ class DownloadAPI(object):
 
     def run(self):
         """Main method."""
-        self.download_dataset()
-        self.update_cache()
+        if not self.exists_dataset_in_cache():
+            self.download_dataset()
+            self.update_cache()
+
+    def exists_dataset_in_cache(self):
+        return self.cache_manager.dataset.exists(self.name)
 
     def download_dataset(self):
         """Download the dataset to disk."""
         if self.verbose:
             print('==> Download {} data to disk...'.format(self.name))
-
         constructor = self.get_dataset_constructor()
         db = constructor(data_path=self.save_data_dir,
                          cache_path=self.save_cache_dir,
@@ -156,9 +159,13 @@ class DownloadAPI(object):
         """Update the cache manager information for this dataset."""
         if self.verbose:
             print('==> Updating the cache manager')
+        if self.exists_dataset_in_cache():
+            self.update_dataset_info_in_cache()
+        else:
+            self.add_dataset_info_to_cache()
 
-        keywords = self.available_datasets_list[self.name]['keywords']
-        self.cache_manager.update(self.name,
-                                  self.save_data_dir,
-                                  {},
-                                  keywords)
+    def update_dataset_info_in_cache(self):
+        self.cache_manager.dataset.update(self.name, data_dir=self.save_data_dir)
+
+    def add_dataset_info_to_cache(self):
+        self.cache_manager.dataset.add(self.name, data_dir=self.save_data_dir, tasks={})

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -47,9 +47,6 @@ def download(name, data_dir=None, extract_data=True, verbose=True):
 
     downloader.run()
 
-    if verbose:
-        print('==> Dataset download complete.')
-
 
 class DownloadAPI(object):
     """Dataset download API class.
@@ -135,16 +132,23 @@ class DownloadAPI(object):
     def run(self):
         """Main method."""
         if not self.exists_dataset_in_cache():
+            if self.verbose:
+                print('==> Download {} data to disk...'.format(self.name))
+
             self.download_dataset()
+            if self.verbose:
+                print('==> Dataset download complete.')
+
             self.update_cache()
+            if self.verbose:
+                print('==> Updating the cache manager')
+
 
     def exists_dataset_in_cache(self):
         return self.cache_manager.dataset.exists(self.name)
 
     def download_dataset(self):
         """Download the dataset to disk."""
-        if self.verbose:
-            print('==> Download {} data to disk...'.format(self.name))
         constructor = self.get_dataset_constructor()
         db = constructor(data_path=self.save_data_dir,
                          cache_path=self.save_cache_dir,
@@ -157,8 +161,6 @@ class DownloadAPI(object):
 
     def update_cache(self):
         """Update the cache manager information for this dataset."""
-        if self.verbose:
-            print('==> Updating the cache manager')
         if self.exists_dataset_in_cache():
             self.update_dataset_info_in_cache()
         else:

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -142,12 +142,15 @@ class DownloadAPI(object):
         if self.verbose:
             print('==> Download {} data to disk...'.format(self.name))
 
-        constructor = self.available_datasets_list[self.name]['constructor']
+        constructor = self.get_dataset_constructor()
         db = constructor(data_path=self.save_data_dir,
                          cache_path=self.save_cache_dir,
                          extract_data=self.extract_data,
                          verbose=self.verbose)
         db.download()
+
+    def get_dataset_constructor(self):
+        return self.available_datasets_list[self.name]['constructor']
 
     def update_cache(self):
         """Update the cache manager information for this dataset."""

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -11,7 +11,7 @@ from dbcollection.core.cache import CacheManager
 from .list_datasets import fetch_list_datasets, check_if_dataset_name_is_valid
 
 
-def download(name, data_dir=None, extract_data=True, verbose=True, is_test=False):
+def download(name, data_dir=None, extract_data=True, verbose=True):
     """Download a dataset data to disk.
 
     This method will download a dataset's data files to disk. After download,
@@ -28,8 +28,6 @@ def download(name, data_dir=None, extract_data=True, verbose=True, is_test=False
         Extracts/unpacks the data files (if true).
     verbose : bool, optional
         Displays text information (if true).
-    is_test : bool, optional
-        Flag used for tests.
 
     Examples
     --------
@@ -45,8 +43,7 @@ def download(name, data_dir=None, extract_data=True, verbose=True, is_test=False
     downloader = DownloadAPI(name=name,
                              data_dir=data_dir,
                              extract_data=extract_data,
-                             verbose=verbose,
-                             is_test=is_test)
+                             verbose=verbose)
 
     downloader.run()
 
@@ -70,8 +67,6 @@ class DownloadAPI(object):
         Extracts/unpacks the data files (if true).
     verbose : bool
         Displays text information (if true).
-    is_test : bool
-        Flag used for tests.
 
     Attributes
     ----------
@@ -87,8 +82,6 @@ class DownloadAPI(object):
         Flag to extract data (if True).
     verbose : bool
         Flag to display text information (if true).
-    is_test : bool
-        Test flag.
     available_datasets_list : dict
         Dictionary of available datasets.
     cache_manager : CacheManager
@@ -96,54 +89,35 @@ class DownloadAPI(object):
 
     """
 
-    def __init__(self, name, data_dir, extract_data, verbose, is_test):
+    def __init__(self, name, data_dir, extract_data, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
         assert extract_data is not None, 'extract_data cannot be empty'
         assert verbose is not None, 'verbose cannot be empty'
-        assert is_test is not None, 'is_test cannot be empty'
 
         self.name = name
         self.data_dir = data_dir
         self.extract_data = extract_data
         self.verbose = verbose
-        self.is_test = is_test
-        self.cache_manager = CacheManager(self.is_test)
+        self.cache_manager = self.get_cache_manager()
         self.available_datasets_list = fetch_list_datasets()
 
-    def run(self):
-        """Main method."""
-        self.set_dataset_dirs()
-        self.download_dataset()
-        self.update_cache()
+        self.save_data_dir = self.get_download_data_dir()
+        self.save_cache_dir = self.get_download_cache_dir()
 
-    def set_dataset_dirs(self):
-        """Set download data + cache dirs in disk."""
-        if self.verbose:
-            print('==> Setup directories to store the data files.')
+    def get_cache_manager(self):
+        return CacheManager()
 
-        self.save_data_dir = self.set_download_data_dir()
-        self.save_cache_dir = self.set_download_cache_dir()
-
-    def set_download_data_dir(self):
-        if self.data_dir is None or self.data_dir is '':
-            save_data_dir = self.set_dir_path_from_cache()
+    def get_download_data_dir(self):
+        if self.data_dir:
+            return self.data_dir
         else:
-            save_data_dir = self.set_dir_path_from_input()
+            return self.get_download_data_dir_from_cache()
 
-        self.create_dir(save_data_dir)
-
-        return save_data_dir
-
-    def set_dir_path_from_cache(self):
+    def get_download_data_dir_from_cache(self):
         """Create a dir path from the cache information for this dataset."""
-        save_data_dir = os.path.join(self.cache_manager.download_dir, self.name)
-        return save_data_dir
-
-    def set_dir_path_from_input(self):
-        save_data_dir = self.data_dir
-        if not os.path.exists(self.data_dir):
-            save_data_dir = os.path.join(self.data_dir, self.name)
+        save_data_dir = os.path.join(self.cache_manager.manager.download_dir, self.name)
+        self.create_dir(save_data_dir)
         return save_data_dir
 
     def create_dir(self, path):
@@ -153,10 +127,15 @@ class DownloadAPI(object):
                 print('Creating save directory in disk: {}'.format(path))
             os.makedirs(path)
 
-    def set_download_cache_dir(self):
-        cache_save_path = os.path.join(self.cache_manager.cache_dir, self.name)
+    def get_download_cache_dir(self):
+        cache_save_path = os.path.join(self.cache_manager.manager.cache_dir, self.name)
         self.create_dir(cache_save_path)
         return cache_save_path
+
+    def run(self):
+        """Main method."""
+        self.download_dataset()
+        self.update_cache()
 
     def download_dataset(self):
         """Download the dataset to disk."""

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -115,3 +115,27 @@ class TestClassDownloadAPI:
         result = download_cls.get_download_data_dir()
 
         assert result == '/some/path/'
+
+    def test_download_dataset__raise_error_invalid_dataset(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        dataset = 'some_dataset'
+        data_dir = '/some/dir/path'
+        extract_data = True
+        verbose = False
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        with pytest.raises(KeyError):
+            download_cls.download_dataset()
+
+    def test_download_dataset_run_constructor(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
+        dataset = 'mnist'
+        data_dir = '/some/dir/path'
+        extract_data = True
+        verbose = False
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        download_cls.download_dataset()
+
+        assert mock_constructor.called

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -6,7 +6,7 @@ Test dbcollection core API: download.
 import pytest
 
 from dbcollection.core.api.download import download, DownloadAPI
-from dbcollection.core.cache import CacheManager, CacheDataManager
+from dbcollection.core.cache import CacheManager
 
 from ..dummy_data.example_cache import DataGenerator
 
@@ -15,6 +15,14 @@ def mock_DownloadAPI_init_methods(mocker):
     mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
     mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/path/to/cache/downloads/')
     mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+
+
+def test_db_data():
+    dataset = 'some_dataset'
+    data_dir = '/some/dir/path/'
+    extract_data = True
+    verbose = False
+    return dataset, data_dir, extract_data, verbose
 
 
 class TestCallDownload:
@@ -33,9 +41,7 @@ class TestCallDownload:
         mock_DownloadAPI_init_methods(mocker)
         mock_run = mocker.patch.object(DownloadAPI, "run")
         dataset = 'mnist'
-        data_dir = '/some/dir/path'
-        extract_data = True
-        verbose = True
+        _, data_dir, extract_data, verbose = test_db_data()
 
         download(dataset, data_dir, extract_data, verbose)
 
@@ -62,10 +68,7 @@ class TestClassDownloadAPI:
 
     def test_init_with_all_inputs(self, mocker):
         mock_DownloadAPI_init_methods(mocker)
-        dataset = 'some_dataset'
-        data_dir = '/some/dir/path'
-        extract_data = True
-        verbose = False
+        dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
 
@@ -82,9 +85,7 @@ class TestClassDownloadAPI:
             download_cls = DownloadAPI()
 
     def test_init__raises_error_missing_one_input(self, mocker):
-        dataset = 'some_dataset'
-        data_dir = '/some/dir/path'
-        extract_data = True
+        dataset, data_dir, extract_data, verbose = test_db_data()
 
         with pytest.raises(TypeError):
             download_cls = DownloadAPI(dataset, data_dir, extract_data)
@@ -92,10 +93,7 @@ class TestClassDownloadAPI:
     def test_get_download_data_dir_return_data_dir(self, mocker):
         mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
         mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
-        dataset = 'some_dataset'
-        data_dir = '/some/dir/path'
-        extract_data = True
-        verbose = False
+        dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         result = download_cls.get_download_data_dir()
@@ -107,9 +105,7 @@ class TestClassDownloadAPI:
         mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
         mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
         mocker.patch.object(DownloadAPI, "get_download_data_dir_from_cache", return_value='/some/path/')
-        dataset = 'some_dataset'
-        extract_data = True
-        verbose = False
+        dataset, _, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         result = download_cls.get_download_data_dir()
@@ -118,10 +114,7 @@ class TestClassDownloadAPI:
 
     def test_download_dataset__raise_error_invalid_dataset(self, mocker):
         mock_DownloadAPI_init_methods(mocker)
-        dataset = 'some_dataset'
-        data_dir = '/some/dir/path'
-        extract_data = True
-        verbose = False
+        dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         with pytest.raises(KeyError):
@@ -130,12 +123,33 @@ class TestClassDownloadAPI:
     def test_download_dataset_run_constructor(self, mocker):
         mock_DownloadAPI_init_methods(mocker)
         mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
-        dataset = 'mnist'
-        data_dir = '/some/dir/path'
-        extract_data = True
-        verbose = False
+        dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         download_cls.download_dataset()
 
         assert mock_constructor.called
+
+    def test_update_cache_dataset_exists(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=True)
+        mock_update = mocker.patch.object(DownloadAPI, "update_dataset_info_in_cache")
+        dataset, data_dir, extract_data, verbose = test_db_data()
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        download_cls.update_cache()
+
+        assert mock_exists.return_value == True
+        assert mock_update.called
+
+    def test_update_cache_dataset_not_exists(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=False)
+        mock_add = mocker.patch.object(DownloadAPI, "add_dataset_info_to_cache")
+        dataset, data_dir, extract_data, verbose = test_db_data()
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        download_cls.update_cache()
+
+        assert mock_exists.return_value == False
+        assert mock_add.called

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -88,3 +88,30 @@ class TestClassDownloadAPI:
 
         with pytest.raises(TypeError):
             download_cls = DownloadAPI(dataset, data_dir, extract_data)
+
+    def test_get_download_data_dir_return_data_dir(self, mocker):
+        mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
+        mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+        dataset = 'some_dataset'
+        data_dir = '/some/dir/path'
+        extract_data = True
+        verbose = False
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        result = download_cls.get_download_data_dir()
+
+        assert result == data_dir
+
+    @pytest.mark.parametrize("data_dir", ['', None])
+    def test_get_download_data_dir_generate_data_dir(self, mocker, data_dir):
+        mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
+        mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+        mocker.patch.object(DownloadAPI, "get_download_data_dir_from_cache", return_value='/some/path/')
+        dataset = 'some_dataset'
+        extract_data = True
+        verbose = False
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+        result = download_cls.get_download_data_dir()
+
+        assert result == '/some/path/'

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -80,3 +80,11 @@ class TestClassDownloadAPI:
     def test_init__raises_error_missing_inputs(self, mocker):
         with pytest.raises(TypeError):
             download_cls = DownloadAPI()
+
+    def test_init__raises_error_missing_one_input(self, mocker):
+        dataset = 'some_dataset'
+        data_dir = '/some/dir/path'
+        extract_data = True
+
+        with pytest.raises(TypeError):
+            download_cls = DownloadAPI(dataset, data_dir, extract_data)

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -1,0 +1,82 @@
+"""
+Test dbcollection core API: download.
+"""
+
+
+import pytest
+
+from dbcollection.core.api.download import download, DownloadAPI
+from dbcollection.core.cache import CacheManager, CacheDataManager
+
+from ..dummy_data.example_cache import DataGenerator
+
+
+def mock_DownloadAPI_init_methods(mocker):
+    mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
+    mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/path/to/cache/downloads/')
+    mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+
+
+class TestCallDownload:
+    """Unit tests for the core api download method."""
+
+    def test_call_with_dataset_name(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_run = mocker.patch.object(DownloadAPI, "run")
+        dataset = 'mnist'
+
+        download(dataset)
+
+        assert mock_run.called
+
+    def test_call_all_parameters(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_run = mocker.patch.object(DownloadAPI, "run")
+        dataset = 'mnist'
+        data_dir = '/some/dir/path'
+        extract_data = True
+        verbose = True
+
+        download(dataset, data_dir, extract_data, verbose)
+
+        assert mock_run.called
+
+    def test_call__raise_error_missing_inputs(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_run = mocker.patch.object(DownloadAPI, "run")
+
+        with pytest.raises(TypeError):
+            download()
+
+    def test_call__raise_error_invalid_dataset_name(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        mock_run = mocker.patch.object(DownloadAPI, "run")
+        dataset = None
+
+        with pytest.raises(AssertionError):
+            download(dataset)
+
+
+class TestClassDownloadAPI:
+    """Unit tests for the DownloadAPI class."""
+
+    def test_init_with_all_inputs(self, mocker):
+        mock_DownloadAPI_init_methods(mocker)
+        dataset = 'some_dataset'
+        data_dir = '/some/dir/path'
+        extract_data = True
+        verbose = False
+
+        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+
+        assert download_cls.name == dataset
+        assert download_cls.data_dir == data_dir
+        assert download_cls.extract_data == extract_data
+        assert download_cls.verbose == verbose
+        assert download_cls.cache_manager == True  # mocked value
+        assert download_cls.save_data_dir == '/path/to/cache/downloads/'
+        assert download_cls.save_cache_dir == '/path/to/cache/'
+
+    def test_init__raises_error_missing_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            download_cls = DownloadAPI()

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -6,7 +6,6 @@ Test dbcollection core API: download.
 import pytest
 
 from dbcollection.core.api.download import download, DownloadAPI
-from dbcollection.core.cache import CacheManager
 
 from ..dummy_data.example_cache import DataGenerator
 


### PR DESCRIPTION
This PR addresses #101 and fixes and refactors the `download()` API method.

Unit tests for the `download()` method and `DownloadAPI` class were added.