### PR TITLE
[Fix] core api process() method

### DIFF
--- a/dbcollection/core/api/list_datasets.py
+++ b/dbcollection/core/api/list_datasets.py
@@ -112,7 +112,7 @@ class DatasetConstructor(object):
         try:
             return available_datasets[name]
         except KeyError:
-            raise KeyError("Dataset '{}' does not exists in the database.".format(name))
+            raise KeyError("Dataset '{}' does not exist in the database.".format(name))
 
     def get_default_task(self):
         """Returns the default task for the dataset."""

--- a/dbcollection/core/api/list_datasets.py
+++ b/dbcollection/core/api/list_datasets.py
@@ -1,5 +1,6 @@
 """
-Fetch the names of all available datasets for download.
+List of methods and classes to manage the available dataset's
+information (metadata) stored in the package.
 """
 
 
@@ -45,9 +46,9 @@ def get_dataset_attributes(name):
             "default_task": getattr(module, 'default_task'),
             "constructor": getattr(module, 'Dataset')
         }
-        return db_fields
     except AttributeError:
-        return None
+        db_fields = None
+    return db_fields
 
 
 def check_if_dataset_name_is_valid(name):
@@ -60,19 +61,71 @@ def get_list_urls_dataset():
     available_datasets = fetch_list_datasets()
     dataset_urls = []
     for name in available_datasets:
-        url_list = []
         urls = available_datasets[name]['urls']
-        for url in urls:
-            if isinstance(url, str):
-                url_list.append(url)
-            elif isinstance(url, dict):
-                try:
-                    url_ = url['url']
-                    url_list.append(url_)
-                except KeyError:
-                    pass  # do nothing
-            else:
-                raise Exception('Unknown format when downloading urls: {}'.format(type(url)))
-        # add list to the out dictionary
+        url_list = get_urls_list(urls)
         dataset_urls.append((name, url_list))
     return dataset_urls
+
+
+def get_urls_list(urls):
+    url_list = []
+    for url in urls:
+        if isinstance(url, str):
+            url_list.append(url)
+        elif isinstance(url, dict):
+            try:
+                url_ = url['url']
+                url_list.append(url_)
+            except KeyError:
+                pass  # do nothing
+        else:
+            raise Exception('Unknown format when downloading urls: {}'.format(type(url)))
+    return url_list
+
+
+class DatasetConstructor(object):
+    """Manages a dataset's metadata and constructor states.
+
+    Parameters
+    ----------
+    name : str
+        Name of the dataset.
+
+    Attributes
+    ----------
+    name : str
+        Name of the dataset.
+    dataset_manager : dict
+        Metadata retrieved from the available datasets database.
+
+    """
+
+    def __init__(self, name):
+        """Initialize class."""
+        assert name, "Must input a valid dataset name."
+        self.name = name
+        self.dataset_manager = self.get_dataset_metadata_from_database(name)
+
+    def get_dataset_metadata_from_database(self, name):
+        """Returns the dataset's metadata and constructor class generator."""
+        available_datasets = fetch_list_datasets()
+        try:
+            return available_datasets[name]
+        except KeyError:
+            raise KeyError("Dataset '{}' does not exists in the database.".format(name))
+
+    def get_default_task(self):
+        """Returns the default task for the dataset."""
+        return self.dataset_manager["default_task"]
+
+    def get_tasks(self):
+        """Returns the available tasks of the dataset."""
+        return self.dataset_manager["tasks"]
+
+    def get_keywords(self, task):
+        """Get the keywords for a task of a dataset."""
+        pass
+
+    def get_constructor(self):
+        """Returns the constructor class to generate the dataset's metadata."""
+        return self.dataset_manager["constructor"]

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -103,6 +103,9 @@ class ProcessAPI(object):
         self.task = self.parse_task_name(task)
         self.check_if_task_exists_in_database()
 
+        self.save_data_dir = self.get_dataset_data_dir_path()
+        self.save_cache_dir = self.get_dataset_cache_dir_path()
+
     def get_cache_manager(self):
         return CacheManager()
 
@@ -130,21 +133,27 @@ class ProcessAPI(object):
         """Checks if a task exists for a dataset."""
         return self.task in self.available_datasets_list[self.name]['tasks']
 
+    def get_dataset_data_dir_path(self):
+        dataset_data_cache = self.get_dataset_metadata_from_cache()
+        return dataset_data_cache['data_dir']
+
+    def get_dataset_metadata_from_cache(self):
+        return self.cache_manager.dataset.get(self.name)
+
+    def get_dataset_cache_dir_path(self):
+        cache_dir = self.get_cache_dir_path_from_cache()
+        return os.path.join(cache_dir, self.name)
+
+    def get_cache_dir_path_from_cache(self):
+        return self.cache_manager.info.cache_dir
+
     def run(self):
         """Main method."""
-        self.set_dataset_dirs()
-        self.process_dataset()
-        self.update_cache()
-
-    def set_dataset_dirs(self):
-        """Set the dataset's data + cache dirs in disk."""
         if self.verbose:
             print('==> Setup directories to store the data files.')
-
-        dset_paths = self.cache_manager.get_dataset_storage_paths(self.name)
-        self.save_data_dir = dset_paths['data_dir']
-        self.save_cache_dir = dset_paths['cache_dir']
         self.create_dir(self.save_cache_dir)
+        self.process_dataset()
+        self.update_cache()
 
     def create_dir(self, path):
         """Create a directory in the disk."""

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -92,7 +92,7 @@ class ProcessAPI(object):
     def __init__(self, name, task, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
-        assert task, 'Must input a valid task name: {}'.format(task)
+        assert task is not None, 'Must input a valid task name: {}'.format(task)
         assert verbose is not None, 'verbose cannot be empty'
 
         self.name = name

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -92,7 +92,7 @@ class ProcessAPI(object):
     def __init__(self, name, task, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
-        assert name, 'Must input a valid task name: {}'.format(task)
+        assert task, 'Must input a valid task name: {}'.format(task)
         assert verbose is not None, 'verbose cannot be empty'
 
         self.name = name

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -11,7 +11,7 @@ from dbcollection.core.cache import CacheManager
 from .list_datasets import fetch_list_datasets, check_if_dataset_name_is_valid
 
 
-def process(name, task='default', verbose=True, is_test=False):
+def process(name, task='default', verbose=True):
     """Process a dataset's metadata and stores it to file.
 
     The data is stored a a HSF5 file for each task composing the dataset's tasks.
@@ -24,8 +24,6 @@ def process(name, task='default', verbose=True, is_test=False):
         Name of the task to process.
     verbose : bool, optional
         Displays text information (if true).
-    is_test : bool, optional
-        Flag used for tests.
 
     Raises
     ------
@@ -45,8 +43,7 @@ def process(name, task='default', verbose=True, is_test=False):
 
     processer = ProcessAPI(name=name,
                            task=task,
-                           verbose=verbose,
-                           is_test=is_test)
+                           verbose=verbose)
 
     processer.run()
 
@@ -69,8 +66,6 @@ class ProcessAPI(object):
         Name of the task to process.
     verbose : bool
         Displays text information (if true).
-    is_test : bool
-        Flag used for tests.
 
     Attributes
     ----------
@@ -80,8 +75,6 @@ class ProcessAPI(object):
         Name of the task to process.
     verbose : bool
         Displays text information (if true).
-    is_test : bool
-        Flag used for tests.
     extract_data : bool
         Flag to extract data (if True).
     cache_manager : CacheManager
@@ -96,19 +89,17 @@ class ProcessAPI(object):
 
     """
 
-    def __init__(self, name, task, verbose, is_test):
+    def __init__(self, name, task, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
         assert name, 'Must input a valid task name: {}'.format(task)
         assert verbose is not None, 'verbose cannot be empty'
-        assert is_test is not None, 'is_test cannot be empty'
 
         self.name = name
         self.task = task
         self.verbose = verbose
-        self.is_test = is_test
         self.extract_data = False
-        self.cache_manager = CacheManager(self.is_test)
+        self.cache_manager = CacheManager()
         self.available_datasets_list = fetch_list_datasets()
 
         self.check_if_task_exists()

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -47,9 +47,6 @@ def process(name, task='default', verbose=True):
 
     processer.run()
 
-    if verbose:
-        print('==> Dataset processing complete.')
-
 
 class ProcessAPI(object):
     """Dataset metadata process API class.
@@ -152,8 +149,17 @@ class ProcessAPI(object):
         if self.verbose:
             print('==> Setup directories to store the data files.')
         self.create_dir(self.save_cache_dir)
+
+        if self.verbose:
+            print('==> Process \'{}\' metadata to disk...'.format(self.name))
         self.process_dataset()
+
+        if self.verbose:
+            print('==> Updating the cache manager')
         self.update_cache()
+
+        if self.verbose:
+            print('==> Dataset processing complete.')
 
     def create_dir(self, path):
         """Create a directory in the disk."""
@@ -162,22 +168,15 @@ class ProcessAPI(object):
 
     def process_dataset(self):
         """Process the dataset's metadata."""
-        if self.verbose:
-            print('==> Process \'{}\' metadata to disk...'.format(self.name))
-
         constructor = self.available_datasets_list[self.name]['constructor']
         db = constructor(data_path=self.save_data_dir,
                          cache_path=self.save_cache_dir,
                          extract_data=self.extract_data,
                          verbose=self.verbose)
-
         self.task_info = db.process(self.task)
 
     def update_cache(self):
         """Update the cache manager information for this dataset."""
-        if self.verbose:
-            print('==> Updating the cache manager')
-
         keywords = self.available_datasets_list[self.name]['keywords']
         self.cache_manager.update(self.name,
                                   self.save_data_dir,

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -96,18 +96,31 @@ class ProcessAPI(object):
         assert verbose is not None, 'verbose cannot be empty'
 
         self.name = name
-        self.task = task
         self.verbose = verbose
         self.extract_data = False
-        self.cache_manager =self.get_cache_manager()
+        self.cache_manager = self.get_cache_manager()
         self.available_datasets_list = fetch_list_datasets()
-
-        self.check_if_task_exists()
+        self.task = self.parse_task_name(task)
+        self.check_if_task_exists_in_database()
 
     def get_cache_manager(self):
         return CacheManager()
 
-    def check_if_task_exists(self):
+    def parse_task_name(self, task):
+        """Parse the input task string."""
+        if task == '':
+            task_parsed = self.get_default_task()
+        elif task == 'default':
+            task_parsed = self.get_default_task()
+        else:
+            task_parsed = task
+        return task_parsed
+
+    def get_default_task(self):
+        """Returns the default task for this dataset."""
+        return self.available_datasets_list[self.name]['default_task']
+
+    def check_if_task_exists_in_database(self):
         """Check if task exists in the list of available tasks for processing."""
         if not self.exists_task():
             raise KeyError('The task \'{}\' does not exists for loading/processing.'
@@ -115,19 +128,7 @@ class ProcessAPI(object):
 
     def exists_task(self):
         """Checks if a task exists for a dataset."""
-        if self.task == '':
-            task = self.get_default_task()
-        elif self.task == 'default':
-            task = self.get_default_task()
-        elif self.task.endswith('_s'):
-            task = self.task[:-2]
-        else:
-            task = self.task
-        return task in self.available_datasets_list[self.name]['tasks']
-
-    def get_default_task(self):
-        """Returns the default task for this dataset."""
-        return self.available_datasets_list[self.name]['default_task']
+        return self.task in self.available_datasets_list[self.name]['tasks']
 
     def run(self):
         """Main method."""

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -154,11 +154,11 @@ class ProcessAPI(object):
 
         if self.verbose:
             print('==> Process \'{}\' metadata to disk...'.format(self.name))
-        self.process_dataset()
+        task_info = self.process_dataset()
 
         if self.verbose:
             print('==> Updating the cache manager')
-        self.update_cache()
+        self.update_cache(task_info)
 
         if self.verbose:
             print('==> Dataset processing complete.')
@@ -175,12 +175,13 @@ class ProcessAPI(object):
                          cache_path=self.save_cache_dir,
                          extract_data=self.extract_data,
                          verbose=self.verbose)
-        self.task_info = db.process(self.task)
+        task_info = db.process(self.task)
+        return task_info
 
     def get_dataset_constructor(self):
         return self.db_metadata.get_constructor()
 
-    def update_cache(self):
+    def update_cache(self, task_info):
         """Update the cache manager information for this dataset."""
         self.cache_manager.update(self.name,
                                   self.save_data_dir,

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -183,7 +183,6 @@ class ProcessAPI(object):
 
     def update_cache(self, task_info):
         """Update the cache manager information for this dataset."""
-        self.cache_manager.update(self.name,
-                                  self.save_data_dir,
-                                  self.task_info,
-                                  keywords)
+        self.cache_manager.dataset.update(name=self.name,
+                                          cache_dir=self.save_cache_dir,
+                                          tasks=task_info)

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -99,10 +99,13 @@ class ProcessAPI(object):
         self.task = task
         self.verbose = verbose
         self.extract_data = False
-        self.cache_manager = CacheManager()
+        self.cache_manager =self.get_cache_manager()
         self.available_datasets_list = fetch_list_datasets()
 
         self.check_if_task_exists()
+
+    def get_cache_manager(self):
+        return CacheManager()
 
     def check_if_task_exists(self):
         """Check if task exists in the list of available tasks for processing."""

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -50,7 +50,7 @@ class TestCallProcess:
             process()
 
     def test_call__raises_error_invalid_dataset_name(self, mocker):
-        with pytest.raises(AssertionError):
+        with pytest.raises(KeyError):
             process('invalid_dataset_name')
 
 

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -56,3 +56,35 @@ class TestCallProcess:
 
 class TestClassDownloadAPI:
     """Unit tests for the DownloadAPI class."""
+
+    def test_init_with_all_inputs(self, mocker):
+        mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
+        dataset = 'mnist'
+        task = 'default'
+        verbose = True
+
+        process_api = ProcessAPI(dataset, task, verbose)
+
+        assert mock_cache.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
+        assert process_api.name == dataset
+        assert process_api.task == 'classification'  # default task name for mnist
+        assert process_api.verbose == verbose
+
+    def test_init__raises_error_missing_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            ProcessAPI()
+
+    @pytest.mark.parametrize("dataset, task, verbose", [
+        ('mnist', 'classification', None),
+        ('mnist', None, True),
+        (None, '', False),
+        ('', 'default', False),
+        (None, None, None)
+    ])
+    def test_init__raises_error_missing_some_inputs(self, mocker, dataset, task, verbose):
+        with pytest.raises(AssertionError):
+            ProcessAPI(dataset, task, verbose)

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -13,6 +13,8 @@ class TestCallProcess:
 
     def test_call_with_dataset_name(self, mocker):
         mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
         mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
         mock_run = mocker.patch.object(ProcessAPI, "run")
         dataset = 'mnist'
@@ -20,11 +22,15 @@ class TestCallProcess:
         process(dataset)
 
         assert mock_cache.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
         assert mock_task_exists.called
         assert mock_run.called
 
     def test_call_with_all_inputs(self, mocker):
         mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
         mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
         mock_run = mocker.patch.object(ProcessAPI, "run")
         dataset = 'mnist'
@@ -34,6 +40,8 @@ class TestCallProcess:
         process(dataset, task=task, verbose=verbose)
 
         assert mock_cache.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
         assert mock_task_exists.called
         assert mock_run.called
 

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -13,7 +13,7 @@ class TestCallProcess:
 
     def test_call_with_dataset_name(self, mocker):
         mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
-        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists")
+        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
         mock_run = mocker.patch.object(ProcessAPI, "run")
         dataset = 'mnist'
 
@@ -25,7 +25,7 @@ class TestCallProcess:
 
     def test_call_with_all_inputs(self, mocker):
         mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
-        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists")
+        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
         mock_run = mocker.patch.object(ProcessAPI, "run")
         dataset = 'mnist'
         task = ''

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -23,6 +23,20 @@ class TestCallProcess:
         assert mock_task_exists.called
         assert mock_run.called
 
+    def test_call_with_all_inputs(self, mocker):
+        mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists")
+        mock_run = mocker.patch.object(ProcessAPI, "run")
+        dataset = 'mnist'
+        task = ''
+        verbose = True
+
+        process(dataset, task=task, verbose=verbose)
+
+        assert mock_cache.called
+        assert mock_task_exists.called
+        assert mock_run.called
+
     def test_call__raises_error_no_inputs(self, mocker):
         with pytest.raises(TypeError):
             process()

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -88,3 +88,31 @@ class TestClassDownloadAPI:
     def test_init__raises_error_missing_some_inputs(self, mocker, dataset, task, verbose):
         with pytest.raises(AssertionError):
             ProcessAPI(dataset, task, verbose)
+
+    @pytest.mark.parametrize("test_task", ['classification', 'some_task', 'another_task'])
+    def test_parse_task_name(self, mocker, test_task):
+        mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
+        mock_exists = mocker.patch.object(ProcessAPI, 'check_if_task_exists_in_database')
+
+        process_api = ProcessAPI('mnist', test_task, True)
+
+        assert mock_cache.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
+        assert mock_exists.called
+        assert process_api.parse_task_name(test_task) == test_task
+
+    @pytest.mark.parametrize("test_task", ['', 'default'])
+    def test_parse_task_name_to_default(self, mocker, test_task):
+        mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
+
+        process_api = ProcessAPI('mnist', '', True)
+
+        assert mock_cache.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
+        assert process_api.parse_task_name(test_task) == "classification"

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -1,0 +1,36 @@
+"""
+Test dbcollection core API: process.
+"""
+
+
+import pytest
+
+from dbcollection.core.api.process import process, ProcessAPI
+
+
+class TestCallProcess:
+    """Unit tests for the core api process method."""
+
+    def test_call_with_dataset_name(self, mocker):
+        mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
+        mock_task_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists")
+        mock_run = mocker.patch.object(ProcessAPI, "run")
+        dataset = 'mnist'
+
+        process(dataset)
+
+        assert mock_cache.called
+        assert mock_task_exists.called
+        assert mock_run.called
+
+    def test_call__raises_error_no_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            process()
+
+    def test_call__raises_error_invalid_dataset_name(self, mocker):
+        with pytest.raises(AssertionError):
+            process('invalid_dataset_name')
+
+
+class TestClassDownloadAPI:
+    """Unit tests for the DownloadAPI class."""

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -113,3 +113,16 @@ class TestClassDownloadAPI:
         assert mock_create.called
         assert mock_process.return_value == "some_info"
         assert mock_update.called
+
+    def test_process_dataset(self, mocker, mocks_init_class):
+        mock_constructor = mocker.patch.object(ProcessAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
+        dataset = 'mnist'
+        task = 'some_task'
+        verbose = True
+
+        process_api = ProcessAPI(dataset, task, verbose)
+        task_info = process_api.process_dataset()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_constructor.called
+        assert task_info is not None

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -97,3 +97,19 @@ class TestClassDownloadAPI:
 
         assert_mock_init_class(mocks_init_class)
         assert process_api.parse_task_name(test_task) == "classification"
+
+    def test_run(self, mocker, mocks_init_class):
+        mock_create = mocker.patch.object(ProcessAPI, "create_dir")
+        mock_process = mocker.patch.object(ProcessAPI, "process_dataset", return_value="some_info")
+        mock_update = mocker.patch.object(ProcessAPI, "update_cache")
+        dataset = 'mnist'
+        task = 'some_task'
+        verbose = True
+
+        process_api = ProcessAPI(dataset, task, verbose)
+        process_api.run()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_create.called
+        assert mock_process.return_value == "some_info"
+        assert mock_update.called


### PR DESCRIPTION
This PR addresses #101 and fixes the `process()` core API method.

A refactor to the `ProcessAPI` class is done, as well as a new class `DatasetConstructor` is added.

Additional unit tests to process() and ProcessAPI are added in this PR.