### PR TITLE
Add DatasetConstructor to download() and refactor tests

### DIFF
--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -8,7 +8,7 @@ import os
 
 from dbcollection.core.cache import CacheManager
 
-from .list_datasets import fetch_list_datasets, check_if_dataset_name_is_valid
+from .list_datasets import DatasetConstructor
 
 
 def download(name, data_dir=None, extract_data=True, verbose=True):
@@ -38,7 +38,6 @@ def download(name, data_dir=None, extract_data=True, verbose=True):
 
     """
     assert name, 'Must input a valid dataset name: {}'.format(name)
-    check_if_dataset_name_is_valid(name)
 
     downloader = DownloadAPI(name=name,
                              data_dir=data_dir,
@@ -79,8 +78,6 @@ class DownloadAPI(object):
         Flag to extract data (if True).
     verbose : bool
         Flag to display text information (if true).
-    available_datasets_list : dict
-        Dictionary of available datasets.
     cache_manager : CacheManager
         Cache manager object.
 
@@ -97,13 +94,16 @@ class DownloadAPI(object):
         self.extract_data = extract_data
         self.verbose = verbose
         self.cache_manager = self.get_cache_manager()
-        self.available_datasets_list = fetch_list_datasets()
+        self.db_metadata = self.get_dataset_metadata_obj(name)
 
         self.save_data_dir = self.get_download_data_dir()
         self.save_cache_dir = self.get_download_cache_dir()
 
     def get_cache_manager(self):
         return CacheManager()
+
+    def get_dataset_metadata_obj(self, name):
+        return DatasetConstructor(name)
 
     def get_download_data_dir(self):
         if self.data_dir:
@@ -157,7 +157,7 @@ class DownloadAPI(object):
         db.download()
 
     def get_dataset_constructor(self):
-        return self.available_datasets_list[self.name]['constructor']
+        return self.db_metadata.get_constructor()
 
     def update_cache(self):
         """Update the cache manager information for this dataset."""

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -10,14 +10,21 @@ from dbcollection.core.api.download import download, DownloadAPI
 from ..dummy_data.example_cache import DataGenerator
 
 
-def mock_DownloadAPI_init_methods(mocker):
-    mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
-    mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/path/to/cache/downloads/')
-    mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+@pytest.fixture()
+def mocks_init_class(mocker):
+    mock_cache = mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
+    mock_data_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/path/to/cache/downloads/')
+    mock_cache_dir = mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
+    return [mock_cache, mock_data_dir, mock_cache_dir]
+
+
+def assert_mock_init_class(mocks):
+    for mock in mocks:
+        assert mock.called
 
 
 def test_db_data():
-    dataset = 'some_dataset'
+    dataset = 'mnist'
     data_dir = '/some/dir/path/'
     extract_data = True
     verbose = False
@@ -27,34 +34,32 @@ def test_db_data():
 class TestCallDownload:
     """Unit tests for the core api download method."""
 
-    def test_call_with_dataset_name(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_call_with_dataset_name(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
         dataset = 'mnist'
 
         download(dataset)
 
+        assert_mock_init_class(mocks_init_class)
         assert mock_run.called
 
-    def test_call_all_parameters(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_call_all_parameters(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
         dataset = 'mnist'
         _, data_dir, extract_data, verbose = test_db_data()
 
         download(dataset, data_dir, extract_data, verbose)
 
+        assert_mock_init_class(mocks_init_class)
         assert mock_run.called
 
-    def test_call__raise_error_missing_inputs(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_call__raise_error_missing_inputs(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
 
         with pytest.raises(TypeError):
             download()
 
-    def test_call__raise_error_invalid_dataset_name(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_call__raise_error_invalid_dataset_name(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
         dataset = None
 
@@ -65,12 +70,12 @@ class TestCallDownload:
 class TestClassDownloadAPI:
     """Unit tests for the DownloadAPI class."""
 
-    def test_init_with_all_inputs(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_init_with_all_inputs(self, mocker, mocks_init_class):
         dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
 
+        assert_mock_init_class(mocks_init_class)
         assert download_cls.name == dataset
         assert download_cls.data_dir == data_dir
         assert download_cls.extract_data == extract_data
@@ -111,26 +116,17 @@ class TestClassDownloadAPI:
 
         assert result == '/some/path/'
 
-    def test_download_dataset__raise_error_invalid_dataset(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
-        dataset, data_dir, extract_data, verbose = test_db_data()
-
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        with pytest.raises(KeyError):
-            download_cls.download_dataset()
-
-    def test_download_dataset_run_constructor(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_download_dataset_run_constructor(self, mocker, mocks_init_class):
         mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
         dataset, data_dir, extract_data, verbose = test_db_data()
 
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         download_cls.download_dataset()
 
+        assert_mock_init_class(mocks_init_class)
         assert mock_constructor.called
 
-    def test_update_cache_dataset_exists(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_update_cache_dataset_exists(self, mocker, mocks_init_class):
         mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=True)
         mock_update = mocker.patch.object(DownloadAPI, "update_dataset_info_in_cache")
         dataset, data_dir, extract_data, verbose = test_db_data()
@@ -138,11 +134,11 @@ class TestClassDownloadAPI:
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         download_cls.update_cache()
 
+        assert_mock_init_class(mocks_init_class)
         assert mock_exists.return_value == True
         assert mock_update.called
 
-    def test_update_cache_dataset_not_exists(self, mocker):
-        mock_DownloadAPI_init_methods(mocker)
+    def test_update_cache_dataset_not_exists(self, mocker, mocks_init_class):
         mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=False)
         mock_add = mocker.patch.object(DownloadAPI, "add_dataset_info_to_cache")
         dataset, data_dir, extract_data, verbose = test_db_data()
@@ -150,5 +146,6 @@ class TestClassDownloadAPI:
         download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
         download_cls.update_cache()
 
+        assert_mock_init_class(mocks_init_class)
         assert mock_exists.return_value == False
         assert mock_add.called


### PR DESCRIPTION
This PR refactors the downloa() API by using `DatasetConstructor` to simplify how the dataset constructor and metadata are managed.

Also, the tests for this method were refactored  to minimize DRY.