### PR TITLE
[Fix] core api load() method

### DIFF
--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -143,7 +143,6 @@ class DownloadAPI(object):
             if self.verbose:
                 print('==> Updating the cache manager')
 
-
     def exists_dataset_in_cache(self):
         return self.cache_manager.dataset.exists(self.name)
 

--- a/dbcollection/core/api/list_datasets.py
+++ b/dbcollection/core/api/list_datasets.py
@@ -118,6 +118,16 @@ class DatasetConstructor(object):
         """Returns the default task for the dataset."""
         return self.dataset_manager["default_task"]
 
+    def parse_task_name(self, task):
+        """Parse the input task string."""
+        if task == '':
+            task_parsed = self.get_default_task()
+        elif task == 'default':
+            task_parsed = self.get_default_task()
+        else:
+            task_parsed = task
+        return task_parsed
+
     def get_tasks(self):
         """Returns the available tasks of the dataset."""
         return self.dataset_manager["tasks"]

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -14,7 +14,7 @@ from .process import ProcessAPI
 from .list_datasets import fetch_list_datasets, check_if_dataset_name_is_valid
 
 
-def load(name, task='default', data_dir=None, verbose=True, is_test=False):
+def load(name, task='default', data_dir=None, verbose=True):
     """Returns a metadata loader of a dataset.
 
     Returns a loader with the necessary functions to manage the selected dataset.
@@ -29,8 +29,6 @@ def load(name, task='default', data_dir=None, verbose=True, is_test=False):
         Directory path to store the downloaded data.
     verbose : bool, optional
         Displays text information (if true).
-    is_test : bool, optional
-        Flag used for tests.
 
     Returns
     -------
@@ -58,8 +56,7 @@ def load(name, task='default', data_dir=None, verbose=True, is_test=False):
     loader = LoadAPI(name=name,
                      task=task,
                      data_dir=data_dir,
-                     verbose=verbose,
-                     is_test=is_test)
+                     verbose=verbose)
 
     data_loader = loader.run()
 
@@ -85,8 +82,6 @@ class LoadAPI(object):
         Directory path to store the downloaded data.
     verbose : bool
         Displays text information (if true).
-    is_test : bool
-        Flag used for tests.
 
     Attributes
     ----------
@@ -98,8 +93,6 @@ class LoadAPI(object):
         Directory path to store the downloaded data.
     verbose : bool
         Displays text information (if true).
-    is_test : bool
-        Flag used for tests.
     cache_manager : CacheManager
         Cache manager object.
     available_datasets_list : list
@@ -107,19 +100,17 @@ class LoadAPI(object):
 
     """
 
-    def __init__(self, name, task, data_dir, verbose, is_test):
+    def __init__(self, name, task, data_dir, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
         assert task, 'Must input a valid task name: {}'.format(task)
         assert verbose is not None, 'verbose cannot be empty'
-        assert is_test is not None, 'is_test cannot be empty'
 
         self.name = name
         self.task = task
         self.data_dir = data_dir
         self.verbose = verbose
-        self.is_test = is_test
-        self.cache_manager = CacheManager(self.is_test)
+        self.cache_manager = CacheManager()
         self.available_datasets_list = fetch_list_datasets()
 
         self.parse_task_name()
@@ -162,8 +153,7 @@ class LoadAPI(object):
         downloader = DownloadAPI(name=self.name,
                                  data_dir=self.data_dir,
                                  extract_data=True,
-                                 verbose=self.verbose,
-                                 is_test=self.is_test)
+                                 verbose=self.verbose)
         downloader.run()
 
     def set_dataset_metadata(self):
@@ -180,8 +170,7 @@ class LoadAPI(object):
         """Process the dataset's metadata."""
         processer = ProcessAPI(name=self.name,
                                task=self.task,
-                               verbose=self.verbose,
-                               is_test=self.is_test)
+                               verbose=self.verbose)
         processer.run()
 
     def get_data_loader(self):

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -11,7 +11,7 @@ from dbcollection.core.loader import DataLoader
 from .download import DownloadAPI
 from .process import ProcessAPI
 
-from .list_datasets import fetch_list_datasets, check_if_dataset_name_is_valid
+from .list_datasets import DatasetConstructor
 
 
 def load(name, task='default', data_dir=None, verbose=True):
@@ -51,7 +51,6 @@ def load(name, task='default', data_dir=None, verbose=True):
 
     """
     assert name, 'Must input a valid dataset name: {}'.format(name)
-    check_if_dataset_name_is_valid(name)
 
     loader = LoadAPI(name=name,
                      task=task,
@@ -110,10 +109,15 @@ class LoadAPI(object):
         self.task = task
         self.data_dir = data_dir
         self.verbose = verbose
-        self.cache_manager = CacheManager()
-        self.available_datasets_list = fetch_list_datasets()
-
+        self.cache_manager = self.get_cache_manager()
+        self.db_metadata = self.get_dataset_metadata_obj(name)
         self.parse_task_name()
+
+    def get_cache_manager(self):
+        return CacheManager()
+
+    def get_dataset_metadata_obj(self, name):
+        return DatasetConstructor(name)
 
     def parse_task_name(self):
         """Validate the task name."""

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -176,15 +176,10 @@ class LoadAPI(object):
 
     def get_data_loader(self):
         """Return a DataLoader object."""
-        data_dir_path, hdf5_filepath = self.get_cache_paths()
-        data_loader = self.get_loader_obj(data_dir_path, hdf5_filepath)
-        return data_loader
-
-    def get_cache_paths(self):
-        """Return the dataset's data dir + hdf5 metadata paths."""
         data_dir_path = self.get_data_dir_path_from_cache()
         hdf5_filepath = self.get_hdf5_file_path_from_cache()
-        return data_dir_path, hdf5_filepath
+        data_loader = self.get_loader_obj(data_dir_path, hdf5_filepath)
+        return data_loader
 
     def get_data_dir_path_from_cache(self):
         dataset_metadata = self.cache_manager.dataset.get(self.name)

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -14,7 +14,7 @@ from .process import ProcessAPI
 from .list_datasets import DatasetConstructor
 
 
-def load(name, task='default', data_dir=None, verbose=True):
+def load(name, task='default', data_dir='', verbose=True):
     """Returns a metadata loader of a dataset.
 
     Returns a loader with the necessary functions to manage the selected dataset.
@@ -103,15 +103,15 @@ class LoadAPI(object):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
         assert task, 'Must input a valid task name: {}'.format(task)
+        assert data_dir is not None, 'Must input a valid directory path: {}'.format(data_dir)
         assert verbose is not None, 'verbose cannot be empty'
 
         self.name = name
-        self.task = task
         self.data_dir = data_dir
         self.verbose = verbose
         self.cache_manager = self.get_cache_manager()
         self.db_metadata = self.get_dataset_metadata_obj(name)
-        self.parse_task_name()
+        self.task = self.parse_task_name(task)
 
     def get_cache_manager(self):
         return CacheManager()
@@ -119,14 +119,9 @@ class LoadAPI(object):
     def get_dataset_metadata_obj(self, name):
         return DatasetConstructor(name)
 
-    def parse_task_name(self):
+    def parse_task_name(self, task):
         """Validate the task name."""
-        if self.task == '' or self.task == 'default':
-            self.task = self.get_default_task()
-
-    def get_default_task(self):
-        """Returns the default task for the dataset."""
-        return self.available_datasets_list[self.name]['default_task']
+        return self.db_metadata.parse_task_name(task)
 
     def run(self):
         """Main method."""

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -8,8 +8,8 @@ from __future__ import print_function
 from dbcollection.core.cache import CacheManager
 from dbcollection.core.loader import DataLoader
 
-from .download import DownloadAPI
-from .process import ProcessAPI
+from .download import download
+from .process import process
 
 from .list_datasets import DatasetConstructor
 
@@ -58,9 +58,6 @@ def load(name, task='default', data_dir='', verbose=True):
                      verbose=verbose)
 
     data_loader = loader.run()
-
-    if verbose:
-        print('==> Dataset loading complete.')
 
     return data_loader
 
@@ -125,66 +122,82 @@ class LoadAPI(object):
 
     def run(self):
         """Main method."""
-        self.set_dataset_data()
+        if not self.dataset_data_exists_in_cache():
+            if self.verbose:
+                print('==> Dataset \'{}\' not found in cache.'.format(self.name))
+                print('Proceeding to download the data files...')
+            self.download_dataset_data()
+
+        if not self.dataset_task_metadata_exists_in_cache():
+            if self.verbose:
+                print('==> Processed metadata not found for dataset \'{}\', task \'{}\'.'
+                      .format(self.name, self.task))
+                print('Proceeding to process the metadata for this task...')
+            self.process_dataset_task_metadata()
+
+        if self.verbose:
+            print('==> Load the dataset\'s metadata.')
         dataset_loader = self.get_data_loader()
+
+        if self.verbose:
+            print('==> Dataset loading complete.')
+
         return dataset_loader
 
-    def set_dataset_data(self):
-        """Setup the dataset's metadata."""
-        if self.verbose:
-            print('==> Setup the dataset\'s metadata.')
+    def dataset_data_exists_in_cache(self):
+        return self.cache_manager.dataset.exists(self.name)
 
-        self.get_dataset_files()
-        self.set_dataset_metadata()
-
-    def get_dataset_files(self):
-        """Download the dataset files if they don't exists in cache."""
-        if not self.is_dataset_files_in_cache():
-            self.download_dataset()
-            self.cache_manager.reload_cache()  # reload the cache's data
-
-    def is_dataset_files_in_cache(self):
-        """Check if the dataset is registered in the cache."""
-        return self.cache_manager.exists_dataset(self.name)
+    def download_dataset_data(self):
+        self.download_dataset()
+        self.reload_cache()
 
     def download_dataset(self):
         """Download the dataset to disk."""
-        downloader = DownloadAPI(name=self.name,
-                                 data_dir=self.data_dir,
-                                 extract_data=True,
-                                 verbose=self.verbose)
-        downloader.run()
+        download(name=self.name,
+                 data_dir=self.data_dir,
+                 extract_data=True,
+                 verbose=self.verbose)
 
-    def set_dataset_metadata(self):
-        """Process the dataset's metadata if it does not exists in cache."""
-        if not self.is_dataset_task_in_cache():
-            self.process_dataset()
-            self.cache_manager.reload_cache()  # reload the cache's
+    def reload_cache(self):
+        self.cache_manager.manager.reload_cache()
 
-    def is_dataset_task_in_cache(self):
-        """Check if the dataset task is registered in the cache."""
-        return self.cache_manager.exists_task(self.name, self.task)
+    def dataset_task_metadata_exists_in_cache(self):
+        return self.cache_manager.task.exists(self.name, self.task)
+
+    def process_dataset_task_metadata(self):
+        self.process_dataset()
+        self.reload_cache()
 
     def process_dataset(self):
         """Process the dataset's metadata."""
-        processer = ProcessAPI(name=self.name,
-                               task=self.task,
-                               verbose=self.verbose)
-        processer.run()
+        process(name=self.name,
+                task=self.task,
+                verbose=self.verbose)
 
     def get_data_loader(self):
         """Return a DataLoader object."""
-        if self.verbose:
-            print('==> Load the dataset\'s metadata.')
-
         data_dir_path, hdf5_filepath = self.get_cache_paths()
-        return DataLoader(name=self.name,
-                          task=self.task,
-                          data_dir=data_dir_path,
-                          hdf5_filepath=hdf5_filepath)
+        data_loader = self.get_loader_obj(data_dir_path, hdf5_filepath)
+        return data_loader
 
     def get_cache_paths(self):
         """Return the dataset's data dir + hdf5 metadata paths."""
-        dset_paths = self.cache_manager.get_dataset_storage_paths(self.name)
-        task_hdf5_filepath = self.cache_manager.get_task_cache_path(self.name, self.task)
-        return dset_paths['data_dir'], task_hdf5_filepath
+        data_dir_path = self.get_data_dir_path_from_cache()
+        hdf5_filepath = self.get_hdf5_file_path_from_cache()
+        return data_dir_path, hdf5_filepath
+
+    def get_data_dir_path_from_cache(self):
+        dataset_metadata = self.cache_manager.dataset.get(self.name)
+        return dataset_metadata["data_dir"]
+
+    def get_hdf5_file_path_from_cache(self):
+        task_metadata = self.cache_manager.task.get(self.name, self.task)
+        return task_metadata["filename"]
+
+    def get_loader_obj(self, data_dir, hdf5_filepath):
+        assert data_dir
+        assert hdf5_filepath
+        return DataLoader(name=self.name,
+                          task=self.task,
+                          data_dir=data_dir,
+                          hdf5_filepath=hdf5_filepath)

--- a/dbcollection/core/cache.py
+++ b/dbcollection/core/cache.py
@@ -382,6 +382,10 @@ class CacheDataManager:
         except KeyError:
             raise KeyError("The dataset \'{}\' does not exist in the cache.".format(name))
 
+    def reload_cache(self):
+        """Reloads the cache data contents by reading the cache file from disk."""
+        self.data = self.read_data_cache()
+
 
 class CacheManagerDataset:
     """Manage the cache's dataset configurations."""

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -71,3 +71,53 @@ class TestCallLoad:
 
 class TestClassLoadAPI:
     """Unit tests for the LoadAPI class."""
+
+    def test_init_with_all_inputs(self, mocker):
+        inputs = generate_inputs_for_load()
+        mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
+        mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+
+        assert mock_parse.called
+        assert mock_cache.called
+        assert load_api.name == inputs["dataset"]
+        assert load_api.task == inputs["task"]
+        assert load_api.data_dir == inputs["data_dir"]
+        assert load_api.verbose == inputs["verbose"]
+
+    def test_init_with_all_inputs_named_args(self, mocker):
+        inputs = generate_inputs_for_load()
+        mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
+        mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
+
+        load_api = LoadAPI(name=inputs["dataset"],
+                           task=inputs["task"],
+                           data_dir=inputs["data_dir"],
+                           verbose=inputs["verbose"])
+
+        assert mock_parse.called
+        assert mock_cache.called
+        assert load_api.name == inputs["dataset"]
+        assert load_api.task == inputs["task"]
+        assert load_api.data_dir == inputs["data_dir"]
+        assert load_api.verbose == inputs["verbose"]
+
+    def test_init__raises_error_missing_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            LoadAPI()
+
+    @pytest.mark.parametrize("dataset, task, data_dir, verbose", [
+        ('mnist', 'classification', 'some_dir', None),
+        ('mnist', 'some_task', None, True),
+        ('some_dataset', None, 'some_dir', False),
+        (None, 'some_task', 'some_dir', False),
+        (None, None, None, None)
+    ])
+    def test_init__raises_error_missing_some_inputs(self, mocker, dataset, task, data_dir, verbose):
+        with pytest.raises(AssertionError):
+            LoadAPI(dataset, task, data_dir, verbose)
+
+    def test_init__raises_error_extra_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            LoadAPI("some_dataset", "some_task", "some_dir", True, "extra_field")

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -1,0 +1,25 @@
+"""
+Test dbcollection core API: load.
+"""
+
+
+import pytest
+
+from dbcollection.core.api.load import load, LoadAPI
+
+
+class TestCallLoad:
+    """Unit tests for the core api load method."""
+
+    def test_call_with_dataset_name(self, mocker):
+        pass
+
+    def test_call_with_all_inputs(self, mocker):
+        pass
+
+    def test_call__raises_error_no_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            load()
+
+class TestClassLoadAPI:
+    """Unit tests for the LoadAPI class."""

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -230,3 +230,21 @@ class TestClassLoadAPI:
         assert_mock_init_class(mocks_init_class)
         assert mock_process.called
         assert mock_reload.called
+
+    def test_get_data_loader(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_data_dir = mocker.patch.object(LoadAPI, "get_data_dir_path_from_cache",
+                                            return_value="/some/path/data/")
+        mock_hdf5_filepath = mocker.patch.object(LoadAPI, "get_hdf5_file_path_from_cache",
+                                            return_value="/some/path/to/file")
+        mock_loader = mocker.patch.object(LoadAPI, "get_loader_obj",
+                                            return_value=["data_loader_dummy"])
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load_api.get_data_loader()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_data_dir.called
+        assert mock_hdf5_filepath.called
+        assert mock_loader.called
+        assert data_loader == ["data_loader_dummy"]

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -12,7 +12,8 @@ from dbcollection.core.api.load import load, LoadAPI
 def mocks_init_class(mocker):
     mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=True)
     mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
-    return [mock_parse, mock_cache]
+    mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
+    return [mock_parse, mock_cache, mock_run]
 
 
 def assert_mock_init_class(mocks):
@@ -20,46 +21,43 @@ def assert_mock_init_class(mocks):
         assert mock.called
 
 
+def generate_inputs_for_load():
+    return {
+        "dataset": 'mnist',
+        "task": 'some_task',
+        "data_dir": '/some/path/',
+        "verbose": True,
+    }
+
+
 class TestCallLoad:
     """Unit tests for the core api load method."""
 
     def test_call_with_dataset_name_only(self, mocker, mocks_init_class):
-        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
-        dataset = 'mnist'
+        inputs = generate_inputs_for_load()
 
-        data_loader = load(dataset)
+        data_loader = load(inputs["dataset"])
 
         assert_mock_init_class(mocks_init_class)
-        assert mock_run.called
         assert data_loader == True
 
     def test_call_with_all_inputs(self, mocker, mocks_init_class):
-        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
-        dataset = 'mnist'
-        task = 'some_task'
-        data_dir = '/some/path/'
-        verbose = True
+        inputs = generate_inputs_for_load()
 
-        data_loader = load(dataset, task, data_dir, verbose)
+        data_loader = load(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
 
         assert_mock_init_class(mocks_init_class)
-        assert mock_run.called
         assert data_loader == True
 
     def test_call_with_all_inputs_named_args(self, mocker, mocks_init_class):
-        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
-        dataset = 'mnist'
-        task = 'some_task'
-        data_dir = '/some/path/'
-        verbose = True
+        inputs = generate_inputs_for_load()
 
-        data_loader = load(name=dataset,
-                           task=task,
-                           data_dir=data_dir,
-                           verbose=verbose)
+        data_loader = load(name=inputs["dataset"],
+                           task=inputs["task"],
+                           data_dir=inputs["data_dir"],
+                           verbose=inputs["verbose"])
 
         assert_mock_init_class(mocks_init_class)
-        assert mock_run.called
         assert data_loader == True
 
     def test_call__raises_error_no_inputs(self, mocker):

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -9,14 +9,14 @@ from dbcollection.core.api.load import load, LoadAPI
 
 
 @pytest.fixture()
-def mocks_init_class(mocker):
+def mocks_api(mocker):
     mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=True)
     mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
     mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
     return [mock_parse, mock_cache, mock_run]
 
 
-def assert_mock_init_class(mocks):
+def assert_mock_api(mocks):
     for mock in mocks:
         assert mock.called
 
@@ -33,23 +33,23 @@ def generate_inputs_for_load():
 class TestCallLoad:
     """Unit tests for the core api load method."""
 
-    def test_call_with_dataset_name_only(self, mocker, mocks_init_class):
+    def test_call_with_dataset_name_only(self, mocker, mocks_api):
         inputs = generate_inputs_for_load()
 
         data_loader = load(inputs["dataset"])
 
-        assert_mock_init_class(mocks_init_class)
+        assert_mock_api(mocks_api)
         assert data_loader == True
 
-    def test_call_with_all_inputs(self, mocker, mocks_init_class):
+    def test_call_with_all_inputs(self, mocker, mocks_api):
         inputs = generate_inputs_for_load()
 
         data_loader = load(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
 
-        assert_mock_init_class(mocks_init_class)
+        assert_mock_api(mocks_api)
         assert data_loader == True
 
-    def test_call_with_all_inputs_named_args(self, mocker, mocks_init_class):
+    def test_call_with_all_inputs_named_args(self, mocker, mocks_api):
         inputs = generate_inputs_for_load()
 
         data_loader = load(name=inputs["dataset"],
@@ -57,7 +57,7 @@ class TestCallLoad:
                            data_dir=inputs["data_dir"],
                            verbose=inputs["verbose"])
 
-        assert_mock_init_class(mocks_init_class)
+        assert_mock_api(mocks_api)
         assert data_loader == True
 
     def test_call__raises_error_no_inputs(self, mocker):
@@ -68,36 +68,42 @@ class TestCallLoad:
         with pytest.raises(TypeError):
             load("some_dataset", "some_task", "some_dir", True, "extra_field")
 
+@pytest.fixture
+def mocks_init_class(mocker):
+    inputs = generate_inputs_for_load()
+    mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
+    mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
+    return [mock_parse, mock_cache]
+
+
+def assert_mock_init_class(mocks):
+    for mock in mocks:
+        assert mock.called
+
 
 class TestClassLoadAPI:
     """Unit tests for the LoadAPI class."""
 
-    def test_init_with_all_inputs(self, mocker):
+    def test_init_with_all_inputs(self, mocker, mocks_init_class):
         inputs = generate_inputs_for_load()
-        mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
-        mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
 
         load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
 
-        assert mock_parse.called
-        assert mock_cache.called
+        assert_mock_init_class(mocks_init_class)
         assert load_api.name == inputs["dataset"]
         assert load_api.task == inputs["task"]
         assert load_api.data_dir == inputs["data_dir"]
         assert load_api.verbose == inputs["verbose"]
 
-    def test_init_with_all_inputs_named_args(self, mocker):
+    def test_init_with_all_inputs_named_args(self, mocker, mocks_init_class):
         inputs = generate_inputs_for_load()
-        mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
-        mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
 
         load_api = LoadAPI(name=inputs["dataset"],
                            task=inputs["task"],
                            data_dir=inputs["data_dir"],
                            verbose=inputs["verbose"])
 
-        assert mock_parse.called
-        assert mock_cache.called
+        assert_mock_init_class(mocks_init_class)
         assert load_api.name == inputs["dataset"]
         assert load_api.task == inputs["task"]
         assert load_api.data_dir == inputs["data_dir"]
@@ -121,3 +127,71 @@ class TestClassLoadAPI:
     def test_init__raises_error_extra_inputs(self, mocker):
         with pytest.raises(TypeError):
             LoadAPI("some_dataset", "some_task", "some_dir", True, "extra_field")
+
+    def test_run_dataset_data_files_and_task_exist_in_cache(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_data_exists = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=True)
+        mock_task_exists = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=True)
+        mock_data_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value=["data_loader_dummy_data"])
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load_api.run()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_data_exists.called
+        assert mock_task_exists.called
+        assert mock_data_loader.called
+        assert data_loader == ["data_loader_dummy_data"]
+
+    def test_run_dataset_data_files_exist_task_missing_in_cache(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_data_exists = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=True)
+        mock_task_exists = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=False)
+        mock_process = mocker.patch.object(LoadAPI, "process_dataset_task_metadata")
+        mock_data_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value=["data_loader_dummy_data"])
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load_api.run()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_data_exists.called
+        assert mock_task_exists.called
+        assert mock_process.called
+        assert mock_data_loader.called
+        assert data_loader == ["data_loader_dummy_data"]
+
+    def test_run_dataset_data_files_missing_task_exists_in_cache(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_data_exists = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=False)
+        mock_download = mocker.patch.object(LoadAPI, "download_dataset_data")
+        mock_task_exists = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=True)
+        mock_data_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value=["data_loader_dummy_data"])
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load_api.run()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_data_exists.called
+        assert mock_task_exists.called
+        assert mock_download.called
+        assert mock_data_loader.called
+        assert data_loader == ["data_loader_dummy_data"]
+
+    def test_run_dataset_files_and_task_missing_in_cache(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_data_exists = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=False)
+        mock_download = mocker.patch.object(LoadAPI, "download_dataset_data")
+        mock_task_exists = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=False)
+        mock_process = mocker.patch.object(LoadAPI, "process_dataset_task_metadata")
+        mock_data_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value=["data_loader_dummy_data"])
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load_api.run()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_data_exists.called
+        assert mock_task_exists.called
+        assert mock_download.called
+        assert mock_data_loader.called
+        assert mock_process.called
+        assert data_loader == ["data_loader_dummy_data"]

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -8,18 +8,68 @@ import pytest
 from dbcollection.core.api.load import load, LoadAPI
 
 
+@pytest.fixture()
+def mocks_init_class(mocker):
+    mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=True)
+    mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
+    return [mock_parse, mock_cache]
+
+
+def assert_mock_init_class(mocks):
+    for mock in mocks:
+        assert mock.called
+
+
 class TestCallLoad:
     """Unit tests for the core api load method."""
 
-    def test_call_with_dataset_name(self, mocker):
-        pass
+    def test_call_with_dataset_name_only(self, mocker, mocks_init_class):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
+        dataset = 'mnist'
 
-    def test_call_with_all_inputs(self, mocker):
-        pass
+        data_loader = load(dataset)
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == True
+
+    def test_call_with_all_inputs(self, mocker, mocks_init_class):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
+        dataset = 'mnist'
+        task = 'some_task'
+        data_dir = '/some/path/'
+        verbose = True
+
+        data_loader = load(dataset, task, data_dir, verbose)
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == True
+
+    def test_call_with_all_inputs_named_args(self, mocker, mocks_init_class):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
+        dataset = 'mnist'
+        task = 'some_task'
+        data_dir = '/some/path/'
+        verbose = True
+
+        data_loader = load(name=dataset,
+                           task=task,
+                           data_dir=data_dir,
+                           verbose=verbose)
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == True
 
     def test_call__raises_error_no_inputs(self, mocker):
         with pytest.raises(TypeError):
             load()
+
+    def test_call__raises_error_extra_inputs(self, mocker):
+        with pytest.raises(TypeError):
+            load("some_dataset", "some_task", "some_dir", True, "extra_field")
+
 
 class TestClassLoadAPI:
     """Unit tests for the LoadAPI class."""

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -218,3 +218,15 @@ class TestClassLoadAPI:
         assert_mock_init_class(mocks_init_class)
         assert mock_download.called
         assert mock_reload.called
+
+    def test_process_dataset_task_metadata(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_process = mocker.patch.object(LoadAPI, "process_dataset")
+        mock_reload = mocker.patch.object(LoadAPI, "reload_cache")
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        load_api.process_dataset_task_metadata()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_process.called
+        assert mock_reload.called

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -206,3 +206,15 @@ class TestClassLoadAPI:
 
         assert_mock_init_class(mocks_init_class)
         eval_run_method_calls(mocks, data_exists=False, task_exists=False)
+
+    def test_download_dataset_data(self, mocker, mocks_init_class):
+        inputs = generate_inputs_for_load()
+        mock_download = mocker.patch.object(LoadAPI, "download_dataset")
+        mock_reload = mocker.patch.object(LoadAPI, "reload_cache")
+
+        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        load_api.download_dataset_data()
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_download.called
+        assert mock_reload.called

--- a/dbcollection/tests/core/test_cache.py
+++ b/dbcollection/tests/core/test_cache.py
@@ -283,6 +283,14 @@ class TestCacheDataManager:
         with pytest.raises(KeyError):
             cache_data_manager.delete_data(name)
 
+    def test_reload_cache(self, mocker, cache_data_manager, test_data):
+        cache_data_manager.data = None
+
+        cache_data_manager.reload_cache()
+
+        assert cache_data_manager.data is not None
+        assert cache_data_manager.data == test_data.data
+
 
 @pytest.fixture()
 def cache_manager(mocker, test_data):


### PR DESCRIPTION
This PR addresses #101 and fixes the `load()` core API method.

A refactor to the `LoadAPI` class is done.

Also, an additional method (`reload_cache()`) was added to `CacheDataManager` to reload the cache data from disk.

Additionally, unit tests to both `load()` and `LoadAPI` are added in this PR.