### PR TITLE
[Fix] core api remove

### DIFF
--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 from dbcollection.core.cache import CacheManager
 
 
-def remove(name, task=None, delete_data=False, verbose=True, is_test=False):
+def remove(name, task=None, delete_data=False, verbose=True):
     """Remove/delete a dataset and/or task from the cache.
 
     Removes the datasets cache information from the dbcollection.json file.
@@ -30,8 +30,6 @@ def remove(name, task=None, delete_data=False, verbose=True, is_test=False):
         Delete all data files from disk for this dataset if True.
     verbose : bool, optional
         Displays text information (if true).
-    is_test : bool, optional
-        Flag used for tests.
 
     Examples
     --------
@@ -54,8 +52,7 @@ def remove(name, task=None, delete_data=False, verbose=True, is_test=False):
     db_remover = RemoveAPI(name=name,
                            task=task,
                            delete_data=delete_data,
-                           verbose=verbose,
-                           is_test=is_test)
+                           verbose=verbose)
 
     db_remover.run()
 
@@ -79,8 +76,6 @@ class RemoveAPI(object):
         Name of the task to delete.
     delete_data : bool
         Delete all data files from disk for this dataset if True.
-    is_test : bool
-        Flag used for tests.
 
     Attributes
     ----------
@@ -90,26 +85,22 @@ class RemoveAPI(object):
         Name of the task to delete.
     delete_data : bool
         Delete all data files from disk for this dataset if True.
-    is_test : bool
-        Flag used for tests.
     cache_manager : CacheManager
         Cache manager object.
 
     """
 
-    def __init__(self, name, task, delete_data, verbose, is_test):
+    def __init__(self, name, task, delete_data, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name: {}'.format(name)
         assert delete_data is not None, 'delete_data cannot be empty'
         assert verbose is not None, 'verbose cannot be empty'
-        assert is_test is not None, 'is_test cannot be empty'
 
         self.name = name
         self.task = task
         self.delete_data = delete_data
         self.verbose = verbose
-        self.is_test = is_test
-        self.cache_manager = CacheManager(self.is_test)
+        self.cache_manager = CacheManager()
 
     def run(self):
         """Main method."""

--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -12,14 +12,15 @@ from dbcollection.core.cache import CacheManager
 def remove(name, task='', delete_data=False, verbose=True):
     """Remove/delete a dataset and/or task from the cache.
 
-    Removes the datasets cache information from the dbcollection.json file.
-    The dataset's data files remain in disk if 'delete_data' is set to False,
-    otherwise it removes also the data files.
+    Removes the dataset's information registry from the dbcollection.json cache file.
+    The dataset's data files remain in disk if 'delete_data' is not enabled.
+    If it kintended to remove the data files as well, the 'delete_data' input arg
+    must be set to 'True' in order to also remove the data files.
 
-    Also, instead of deleting the entire dataset, removing a specific task
-    from disk is also possible by specifying which task to delete. This removes
-    the task entry for the dataset and removes the corresponding hdf5 file from
-    disk.
+    Moreover, if the intended action is to remove a task of the dataset from the cache
+    registry, this can be achieved by specifying the task name to be deleted. This
+    effectively removes only that task entry for the dataset. Note that deleting a task
+    results in removing the associated HDF5 metadata file from disk.
 
     Parameters
     ----------

--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 from dbcollection.core.cache import CacheManager
 
 
-def remove(name, task=None, delete_data=False, verbose=True):
+def remove(name, task='', delete_data=False, verbose=True):
     """Remove/delete a dataset and/or task from the cache.
 
     Removes the datasets cache information from the dbcollection.json file.
@@ -93,7 +93,7 @@ class RemoveAPI(object):
     def __init__(self, name, task, delete_data, verbose):
         """Initialize class."""
         assert name, 'Must input a valid dataset name.'
-        assert task, 'Must input a valid task name.'
+        assert isinstance(task, str), 'Must input a valid task name.'
         assert isinstance(delete_data, bool), "Must input a valid boolean for delete_data."
         assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
 

--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -101,7 +101,10 @@ class RemoveAPI(object):
         self.task = task
         self.delete_data = delete_data
         self.verbose = verbose
-        self.cache_manager = CacheManager()
+        self.cache_manager = self.get_cache_manager()
+
+    def get_cache_manager(self):
+        return CacheManager()
 
     def run(self):
         """Main method."""

--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -47,7 +47,7 @@ def remove(name, task=None, delete_data=False, verbose=True):
     {}
 
     """
-    assert name is not None, 'Must input a valid dataset name: {}'.format(name)
+    assert name, 'Must input a valid dataset name.'
 
     db_remover = RemoveAPI(name=name,
                            task=task,
@@ -92,9 +92,10 @@ class RemoveAPI(object):
 
     def __init__(self, name, task, delete_data, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name: {}'.format(name)
-        assert delete_data is not None, 'delete_data cannot be empty'
-        assert verbose is not None, 'verbose cannot be empty'
+        assert name, 'Must input a valid dataset name.'
+        assert task, 'Must input a valid task name.'
+        assert isinstance(delete_data, bool), "Must input a valid boolean for delete_data."
+        assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
 
         self.name = name
         self.task = task

--- a/dbcollection/tests/core/api/test_remove.py
+++ b/dbcollection/tests/core/api/test_remove.py
@@ -8,9 +8,64 @@ import pytest
 from dbcollection.core.api.remove import remove, RemoveAPI
 
 
+@pytest.fixture()
+def mocks_init_class(mocker):
+    mock_cache = mocker.patch.object(RemoveAPI, "get_cache_manager", return_value=True)
+    return [mock_cache]
+
+
+def assert_mock_call(mocks):
+    for mock in mocks:
+        assert mock.called
+
+
+@pytest.fixture()
+def test_data():
+    return {
+        "dataset": 'some_db',
+        "task": "taskA",
+        "delete_data": False,
+        "verbose": True,
+    }
+
+
 class TestCallRemove:
     """Unit tests for the core api remove method."""
 
+    def test_call(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(RemoveAPI, 'run')
+
+        remove(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'])
+
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
+
+    def test_call_with_named_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(RemoveAPI, 'run')
+
+        remove(name=test_data['dataset'],
+               task=test_data['task'],
+               delete_data=test_data['delete_data'],
+               verbose=test_data['verbose'])
+
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
+
+    def test_call_without_optional_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(RemoveAPI, 'run')
+
+        remove(test_data['dataset'])
+
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
+
+    def test_call__raises_error_missing_args(self, mocker):
+        with pytest.raises(TypeError):
+            remove()
+
+    def test_call__raises_error_too_many_args(self, mocker, test_data):
+        with pytest.raises(TypeError):
+            remove(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'], 'extra_input')
 
 class TestClassRemoveAPI:
     """Unit tests for the RemoveAPI class."""

--- a/dbcollection/tests/core/api/test_remove.py
+++ b/dbcollection/tests/core/api/test_remove.py
@@ -67,5 +67,30 @@ class TestCallRemove:
         with pytest.raises(TypeError):
             remove(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'], 'extra_input')
 
+
 class TestClassRemoveAPI:
     """Unit tests for the RemoveAPI class."""
+
+    def test_init_with_all_input_agrs(self, mocker, mocks_init_class, test_data):
+        remove_api = RemoveAPI(name=test_data['dataset'],
+                               task=test_data['task'],
+                               delete_data=test_data['delete_data'],
+                               verbose=test_data['verbose'])
+
+        assert_mock_call(mocks_init_class)
+        assert remove_api.name == test_data['dataset']
+        assert remove_api.task == test_data['task']
+        assert remove_api.delete_data == test_data['delete_data']
+        assert remove_api.verbose == test_data['verbose']
+
+    def test_init__raises_error_no_input_args(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            RemoveAPI()
+
+    def test_init__raises_error_too_many_input_args(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            RemoveAPI(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'], 'extra_input')
+
+    def test_init__raises_error_missing_one_input_arg(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            RemoveAPI(test_data['dataset'], test_data['task'], test_data['delete_data'])

--- a/dbcollection/tests/core/api/test_remove.py
+++ b/dbcollection/tests/core/api/test_remove.py
@@ -32,7 +32,7 @@ def test_data():
 class TestCallRemove:
     """Unit tests for the core api remove method."""
 
-    def test_call(self, mocker, mocks_init_class, test_data):
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(RemoveAPI, 'run')
 
         remove(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'])
@@ -40,7 +40,7 @@ class TestCallRemove:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call_with_named_args(self, mocker, mocks_init_class, test_data):
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(RemoveAPI, 'run')
 
         remove(name=test_data['dataset'],
@@ -51,7 +51,7 @@ class TestCallRemove:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call_without_optional_args(self, mocker, mocks_init_class, test_data):
+    def test_call_without_optional_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(RemoveAPI, 'run')
 
         remove(test_data['dataset'])
@@ -59,7 +59,7 @@ class TestCallRemove:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call__raises_error_missing_args(self, mocker):
+    def test_call__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
             remove()
 

--- a/dbcollection/tests/core/api/test_remove.py
+++ b/dbcollection/tests/core/api/test_remove.py
@@ -1,0 +1,16 @@
+"""
+Test dbcollection core API: remove.
+"""
+
+
+import pytest
+
+from dbcollection.core.api.remove import remove, RemoveAPI
+
+
+class TestCallRemove:
+    """Unit tests for the core api remove method."""
+
+
+class TestClassRemoveAPI:
+    """Unit tests for the RemoveAPI class."""


### PR DESCRIPTION
This PR addresses #101 and fixes + refactors the core api `remove()` method.

Additionally, unit tests are also added and the method's docstring has been improved.