### PR TITLE
[Refactor] merge core api config_cache and query methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ test-loader:
 	make build
 	pipenv run pytest -v dbcollection/tests/core/test_loader.py
 
+.PHONY: test-utils
+test-utils:
+	make build
+	pipenv run pytest -v dbcollection/tests/utils
+
 .PHONY: lint
 lint:
 	pipenv run tox -e flake8

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -66,7 +66,10 @@ def cache(query=(), delete_cache=False, delete_cache_dir=False, delete_cache_fil
     >>> dbc.cache(delete_cache_file=True)
 
     """
-    cache = CacheAPI(query=query,
+    if isinstance(query, str):
+        query = (query, )
+
+    cache = CacheAPI(query=tuple(query),
                      delete_cache=delete_cache,
                      delete_cache_dir=delete_cache_dir,
                      delete_cache_file=delete_cache_file,
@@ -89,8 +92,8 @@ class CacheAPI(object):
 
     Parameters
     ----------
-    query : str/list/tuple, optional
-        Pattern or list of patterns to search for in the cache file.
+    query : tuple, optional
+        List of patterns to search for in the cache file.
     delete_cache : bool, optional
         Delete/remove the dbcollection cache file + directory.
     delete_cache_dir : bool, optional
@@ -119,7 +122,7 @@ class CacheAPI(object):
                  reset_cache, reset_path_cache, reset_path_downloads,
                  set_cache_dir, set_downloads_dir, verbose):
         """Initialize class."""
-        assert isinstance(query, (str, list, tuple)), "Must input a valid query."
+        assert isinstance(query, tuple), "Must input a valid query."
         assert isinstance(delete_cache, bool), "Must input a valid boolean for delete_cache."
         assert isinstance(delete_cache_dir, bool), "Must input a valid boolean for delete_cache_dir."
         assert isinstance(delete_cache_file, bool), "Must input a valid boolean for delete_cache_file."

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -182,6 +182,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('Reseted the cache dir path: {}.'.format(self.get_cache_dir()))
 
+        if self.reset_path_downloads and not self.reset_cache:
+            self.reset_download_dir_path()
+            if self.verbose:
+                print('Reseted the download dir path: {}.'.format(self.get_download_dir()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -230,3 +235,9 @@ class CacheAPI(object):
 
     def reset_cache_dir_path(self):
         self.cache_manager.manager.reset_cache_dir()
+
+    def reset_download_dir_path(self):
+        self.cache_manager.manager.reset_download_dir()
+
+    def get_download_dir(self):
+        return self.cache_manager.manager.download_dir

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -4,6 +4,8 @@ Cache API class.
 
 
 from __future__ import print_function
+import os
+import shutil
 
 from dbcollection.core.cache import CacheManager
 from dbcollection.utils import nested_lookup
@@ -160,6 +162,11 @@ class CacheAPI(object):
 
             return result
 
+        if self.delete_cache_dir or self.delete_cache:
+            self.remove_cache_dir_from_disk()
+            if self.verbose:
+                print('Deleted {} directory.'.format(self.get_cache_dir()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -186,3 +193,14 @@ class CacheAPI(object):
 
     def add_key_to_results(self, results, pattern):
         return [{pattern: result} for result in results]
+
+    def remove_cache_dir_from_disk(self):
+        cache_dir = self.get_cache_dir()
+        if self.exists_dir(cache_dir):
+            shutil.rmtree(cache_dir)
+
+    def exists_dir(self, cache_dir):
+        return os.path.exists(cache_dir)
+
+    def get_cache_dir(self):
+        return self.cache_manager.manager.cache_dir

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -8,13 +8,117 @@ from __future__ import print_function
 from dbcollection.core.cache import CacheManager
 
 
-def cache():
+def cache(query='', delete_cache=False, delete_cache_dir=False, delete_cache_file=False,
+          reset_cache=False, reset_path_cache=False, reset_path_downloads=False,
+          set_cache_dir=None, set_downloads_dir=None, verbose=True):
+    """Configures the cache file.
+
+    This method allows to configure some options of the cache file. The
+    available options are only a subset of all possible parameters/registries
+    of the cache file. These provides the most common operations one may need
+    to perform. For more specific configurations, manually modifying the cache
+    file or using the cache manager methods is the best procedure.
+
+    The most common operations one might need to perform are setting, deleting
+    or reseting the cache file itself and/or the existing data. (The input args
+    for these operations should be self-explanatory just by looking at their
+    name description.)
+
+    Additionally, performing basic queries to the cache is supported via the
+    'query' input arg. To search for a particular pattern (e.g., a dataset or
+    task) just assign the 'query' to the pattern you are looking for.
+
+    Parameters
+    ----------
+    delete_cache : bool, optional
+        Delete/remove the dbcollection cache file + directory.
+    delete_cache_dir : bool, optional
+        Delete/remove the dbcollection cache directory.
+    delete_cache_file : bool, optional
+        Delete/remove the dbcollection.json cache file.
+    query : str/list, optional
+        Pattern or list of patterns to search for in the cache file.
+    reset_cache : bool, optional
+        Reset the cache file.
+    reset_cache_dir_path : bool, optional
+        Reset the cache dir path to the default path.
+    reset_cache_downloads_path : bool, optional
+        Reset the downloads dir path to the default path.
+    set_cache_dir_path : str, optional
+        New path for the cache dir.
+    set_downloads_dir : str, optional
+        New path for the downloads dir.
+    verbose : bool, optional
+        Displays text information (if true).
+
+    Returns
+    -------
+    str/list
+        Pattern or list of patterns matching the input query pattern.
+
+    Examples
+    --------
+    Delete the cache by removing the dbcollection.json cache file.
+    This will NOT remove the file contents in dbcollection/. For that,
+    you must set the *delete_cache_dir* argument to True.
+
+    >>> import dbcollection as dbc
+    >>> dbc.cache(delete_cache_file=True)
+
     """
-    """
-    pass
+    cache = CacheAPI(query=query,
+                     delete_cache=delete_cache,
+                     delete_cache_dir=delete_cache_dir,
+                     delete_cache_file=delete_cache_file,
+                     reset_cache=reset_cache,
+                     reset_path_cache=reset_path_cache,
+                     reset_path_downloads=reset_path_downloads,
+                     set_cache_dir=set_cache_dir,
+                     set_downloads_dir=set_downloads_dir,
+                     verbose=verbose)
+
+    return cache.run()
 
 
 class CacheAPI(object):
+    """Cache configuration API class.
+
+    This class contains methods to configure the
+    cache registry. Also, it can remove the cache
+    files from disk if needed.
+
+    Parameters
+    ----------
+    delete_cache : bool, optional
+        Delete/remove the dbcollection cache file + directory.
+    delete_cache_dir : bool, optional
+        Delete/remove the dbcollection cache directory.
+    delete_cache_file : bool, optional
+        Delete/remove the dbcollection.json cache file.
+    query : str/list, optional
+        Pattern or list of patterns to search for in the cache file.
+    reset_cache : bool, optional
+        Reset the cache file.
+    reset_cache_dir_path : bool, optional
+        Reset the cache dir path to the default path.
+    reset_cache_downloads_path : bool, optional
+        Reset the downloads dir path to the default path.
+    set_cache_dir_path : str, optional
+        New path for the cache dir.
+    set_downloads_dir : str, optional
+        New path for the downloads dir.
+    verbose : bool, optional
+        Displays text information (if true).
+
+    Attributes
+    ----------
+
     """
-    """
-    pass
+
+    def __init__(self, delete_cache, delete_cache_dir, delete_cache_file,
+                 reset_cache, reset_path_cache, reset_path_downloads,
+                 set_cache_dir, set_downloads_dir, query, verbose):
+        pass
+
+    def run(self):
+        pass

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -6,6 +6,7 @@ Cache API class.
 from __future__ import print_function
 
 from dbcollection.core.cache import CacheManager
+from dbcollection.utils import nested_lookup
 
 
 def cache(query=(), delete_cache=False, delete_cache_dir=False, delete_cache_file=False,
@@ -156,5 +157,29 @@ class CacheAPI(object):
                 print('==> Patterns found in cache: {}/{}'.format(len(result), len(self.query)))
             return result
 
-    def get_matching_metadata_from_cache(self, query):
-        pass
+    def get_matching_metadata_from_cache(self, patterns):
+        """Returns a list of matching patterns from the cache."""
+        found = []
+        for pattern in patterns:
+            if any(pattern):
+                result = self.get_matching_pattern_from_cache(pattern)
+            else:
+                result = []
+            found.append(result)
+        return found
+
+    def get_matching_pattern_from_cache(self, pattern):
+        """Returns data from cache that matches the pattern."""
+        data = self.get_cache_data()
+        results = self.find_pattern_in_dict(data, pattern)
+        out = self.add_key_to_results(results, pattern)
+        return out
+
+    def get_cache_data(self):
+        return self.cache_manager.manager.data
+
+    def find_pattern_in_dict(self, data, pattern):
+        return list(nested_lookup(key=pattern, document=data, wild=True))
+
+    def add_key_to_results(self, results, pattern):
+        return [{pattern: result} for result in results]

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -154,7 +154,10 @@ class CacheAPI(object):
             result = self.get_matching_metadata_from_cache(self.query)
 
             if self.verbose:
-                print('==> Patterns found in cache: {}/{}'.format(len(result), len(self.query)))
+                print('==> Patterns found in cache:')
+                for i, pattern in enumerate(self.query):
+                    print('    - {}: {} found'.format(pattern, len(result[i])))
+
             return result
 
     def get_matching_metadata_from_cache(self, patterns):

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -8,9 +8,9 @@ from __future__ import print_function
 from dbcollection.core.cache import CacheManager
 
 
-def cache(query='', delete_cache=False, delete_cache_dir=False, delete_cache_file=False,
+def cache(query=(), delete_cache=False, delete_cache_dir=False, delete_cache_file=False,
           reset_cache=False, reset_path_cache=False, reset_path_downloads=False,
-          set_cache_dir=None, set_downloads_dir=None, verbose=True):
+          set_cache_dir='', set_downloads_dir='', verbose=True):
     """Configures the cache file.
 
     This method allows to configure some options of the cache file. The
@@ -30,14 +30,14 @@ def cache(query='', delete_cache=False, delete_cache_dir=False, delete_cache_fil
 
     Parameters
     ----------
+    query : str/list/tuple, optional
+        Pattern or list of patterns to search for in the cache file.
     delete_cache : bool, optional
         Delete/remove the dbcollection cache file + directory.
     delete_cache_dir : bool, optional
         Delete/remove the dbcollection cache directory.
     delete_cache_file : bool, optional
         Delete/remove the dbcollection.json cache file.
-    query : str/list, optional
-        Pattern or list of patterns to search for in the cache file.
     reset_cache : bool, optional
         Reset the cache file.
     reset_cache_dir_path : bool, optional
@@ -89,14 +89,14 @@ class CacheAPI(object):
 
     Parameters
     ----------
+    query : str/list/tuple, optional
+        Pattern or list of patterns to search for in the cache file.
     delete_cache : bool, optional
         Delete/remove the dbcollection cache file + directory.
     delete_cache_dir : bool, optional
         Delete/remove the dbcollection cache directory.
     delete_cache_file : bool, optional
         Delete/remove the dbcollection.json cache file.
-    query : str/list, optional
-        Pattern or list of patterns to search for in the cache file.
     reset_cache : bool, optional
         Reset the cache file.
     reset_cache_dir_path : bool, optional
@@ -115,10 +115,35 @@ class CacheAPI(object):
 
     """
 
-    def __init__(self, delete_cache, delete_cache_dir, delete_cache_file,
+    def __init__(self, query, delete_cache, delete_cache_dir, delete_cache_file,
                  reset_cache, reset_path_cache, reset_path_downloads,
-                 set_cache_dir, set_downloads_dir, query, verbose):
-        pass
+                 set_cache_dir, set_downloads_dir, verbose):
+        """Initialize class."""
+        assert isinstance(query, (str, list, tuple)), "Must input a valid query."
+        assert isinstance(delete_cache, bool), "Must input a valid boolean for delete_cache."
+        assert isinstance(delete_cache_dir, bool), "Must input a valid boolean for delete_cache_dir."
+        assert isinstance(delete_cache_file, bool), "Must input a valid boolean for delete_cache_file."
+        assert isinstance(reset_cache, bool), "Must input a valid boolean for reset_cache."
+        assert isinstance(reset_path_cache, bool), "Must input a valid boolean for reset_path_cache."
+        assert isinstance(reset_path_downloads, bool), "Must input a valid boolean for reset_path_downloads."
+        assert isinstance(set_cache_dir, str), "Must input a valid string for set_cache_dir."
+        assert isinstance(set_downloads_dir, str), "Must input a valid string for set_downloads_dir."
+        assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
+
+        self.query = query
+        self.delete_cache = delete_cache
+        self.delete_cache_dir = delete_cache_dir
+        self.delete_cache_file = delete_cache_file
+        self.reset_cache = reset_cache
+        self.reset_path_cache = reset_path_cache
+        self.reset_path_downloads = reset_path_downloads
+        self.set_cache_dir = set_cache_dir
+        self.set_downloads_dir = set_downloads_dir
+        self.verbose = verbose
+        self.cache_manager = self.get_cache_manager()
+
+    def get_cache_manager(self):
+        return CacheManager()
 
     def run(self):
         pass

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -187,6 +187,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('Reseted the download dir path: {}.'.format(self.get_download_dir()))
 
+        if any(self.set_cache_dir):
+            self.set_cache_dir_path()
+            if self.verbose:
+                print('New cache dir path: {}.'.format(self.get_cache_dir()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -241,3 +246,6 @@ class CacheAPI(object):
 
     def get_download_dir(self):
         return self.cache_manager.manager.download_dir
+
+    def set_cache_dir_path(self):
+        self.cache_manager.manager.cache_dir = self.set_cache_dir

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -167,6 +167,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('Deleted {} directory.'.format(self.get_cache_dir()))
 
+        if self.delete_cache_file or self.delete_cache:
+            self.remove_cache_file_from_disk()
+            if self.verbose:
+                print('Deleted {} cache file.'.format(self.get_cache_filename()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -201,3 +206,11 @@ class CacheAPI(object):
 
     def get_cache_dir(self):
         return self.cache_manager.manager.cache_dir
+
+    def remove_cache_file_from_disk(self):
+        cache_filename = self.get_cache_filename()
+        if os.path.exists(cache_filename):
+            os.remove(cache_filename)
+
+    def get_cache_filename(self):
+        return self.cache_manager.manager.cache_filename

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -192,6 +192,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('New cache dir path: {}.'.format(self.get_cache_dir()))
 
+        if any(self.set_downloads_dir):
+            self.set_download_dir_path()
+            if self.verbose:
+                print('New download dir path: {}.'.format(self.get_download_dir()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -249,3 +254,6 @@ class CacheAPI(object):
 
     def set_cache_dir_path(self):
         self.cache_manager.manager.cache_dir = self.set_cache_dir
+
+    def set_download_dir_path(self):
+        self.cache_manager.manager.download_dir = self.set_downloads_dir

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -149,4 +149,12 @@ class CacheAPI(object):
         return CacheManager()
 
     def run(self):
+        if any(self.query):
+            result = self.get_matching_metadata_from_cache(self.query)
+
+            if self.verbose:
+                print('==> Patterns found in cache: {}/{}'.format(len(result), len(self.query)))
+            return result
+
+    def get_matching_metadata_from_cache(self, query):
         pass

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -1,0 +1,22 @@
+"""
+Cache API class.
+"""
+
+
+from __future__ import print_function
+import os
+import shutil
+
+from dbcollection.core.cache import CacheManager
+
+
+def cache():
+    """
+    """
+    pass
+
+
+class CacheAPI(object):
+    """
+    """
+    pass

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -196,11 +196,8 @@ class CacheAPI(object):
 
     def remove_cache_dir_from_disk(self):
         cache_dir = self.get_cache_dir()
-        if self.exists_dir(cache_dir):
+        if os.path.exists(cache_dir):
             shutil.rmtree(cache_dir)
-
-    def exists_dir(self, cache_dir):
-        return os.path.exists(cache_dir)
 
     def get_cache_dir(self):
         return self.cache_manager.manager.cache_dir

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -172,6 +172,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('Deleted {} cache file.'.format(self.get_cache_filename()))
 
+        if self.reset_cache:
+            self.reset_cache_file()
+            if self.verbose:
+                print('Cache reseted.')
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -214,3 +219,6 @@ class CacheAPI(object):
 
     def get_cache_filename(self):
         return self.cache_manager.manager.cache_filename
+
+    def reset_cache_file(self):
+        self.cache_manager.manager.reset_cache(force_reset=True)

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -4,8 +4,6 @@ Cache API class.
 
 
 from __future__ import print_function
-import os
-import shutil
 
 from dbcollection.core.cache import CacheManager
 

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -177,6 +177,11 @@ class CacheAPI(object):
             if self.verbose:
                 print('Cache reseted.')
 
+        if self.reset_path_cache and not self.reset_cache:
+            self.reset_cache_dir_path()
+            if self.verbose:
+                print('Reseted the cache dir path: {}.'.format(self.get_cache_dir()))
+
     def get_matching_metadata_from_cache(self, patterns):
         """Returns a list of matching patterns from the cache."""
         found = []
@@ -222,3 +227,6 @@ class CacheAPI(object):
 
     def reset_cache_file(self):
         self.cache_manager.manager.reset_cache(force_reset=True)
+
+    def reset_cache_dir_path(self):
+        self.cache_manager.manager.reset_cache_dir()

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -95,6 +95,22 @@ class TestCallCache:
                   'extra_input')
 
 
+@pytest.fixture()
+def cache_api_cls(mocker, mocks_init_class, test_data):
+    return CacheAPI(
+        query=(test_data["query"],),
+        delete_cache=test_data["delete_cache"],
+        delete_cache_dir=test_data["delete_cache_dir"],
+        delete_cache_file=test_data["delete_cache_file"],
+        reset_cache=test_data["reset_cache"],
+        reset_path_cache=test_data["reset_path_cache"],
+        reset_path_downloads=test_data["reset_path_downloads"],
+        set_cache_dir=test_data["set_cache_dir"],
+        set_downloads_dir=test_data["set_downloads_dir"],
+        verbose=test_data["verbose"]
+    )
+
+
 class TestClassCacheAPI:
     """Unit tests for the CacheAPI class."""
 
@@ -128,5 +144,11 @@ class TestClassCacheAPI:
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 
-    def test_run(self, mocker):
-        pass
+    def test_run_query_only(self, mocker, cache_api_cls):
+        mock_query = mocker.patch.object(CacheAPI, 'get_matching_metadata_from_cache',
+                                         return_value=('some', 'vals'))
+
+        result = cache_api_cls.run()
+
+        assert mock_query.called
+        assert result == ('some', 'vals')

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -152,3 +152,54 @@ class TestClassCacheAPI:
 
         assert mock_query.called
         assert result == ('some', 'vals')
+
+    def test_get_matching_metadata_from_cache_and_return_some_patterns(self, mocker, cache_api_cls):
+        def side_effect(pattern):
+            return [{pattern: 'val'}]
+        mock_get_patterns = mocker.patch.object(CacheAPI, 'get_matching_pattern_from_cache', side_effect=side_effect)
+        patterns = ('dbA', 'taskB')
+
+        result = cache_api_cls.get_matching_metadata_from_cache(patterns)
+
+        assert mock_get_patterns.called
+        assert result == [[{"dbA": 'val'}], [{"taskB": 'val'}]]
+
+    def test_get_matching_metadata_from_cache_and_return_empty_list(self, mocker, cache_api_cls):
+        def side_effect(pattern):
+            if any(pattern):
+                return [{pattern: 'val'}]
+            else:
+                return []
+        mock_get_patterns = mocker.patch.object(CacheAPI, 'get_matching_pattern_from_cache', side_effect=side_effect)
+        patterns = ('',)
+
+        result = cache_api_cls.get_matching_metadata_from_cache(patterns)
+
+        assert not mock_get_patterns.called
+        assert result == [[]]
+
+    def test_get_matching_metadata_from_cache_and_return_half_empty_list(self, mocker, cache_api_cls):
+        def side_effect(pattern):
+            if any(pattern):
+                return [{pattern: 'val'}]
+            else:
+                return []
+        mock_get_patterns = mocker.patch.object(CacheAPI, 'get_matching_pattern_from_cache', side_effect=side_effect)
+        patterns = ('', 'taskB')
+
+        result = cache_api_cls.get_matching_metadata_from_cache(patterns)
+
+        assert mock_get_patterns.called
+        assert result == [[], [{"taskB": 'val'}]]
+
+    def test_get_matching_pattern_from_cache(self, mocker, cache_api_cls):
+        mock_data = mocker.patch.object(CacheAPI, 'get_cache_data')
+        mock_find_pattern = mocker.patch.object(CacheAPI, 'find_pattern_in_dict')
+        mock_add_key = mocker.patch.object(CacheAPI, 'add_key_to_results', return_value={})
+
+        result = cache_api_cls.get_matching_pattern_from_cache('some_pattern')
+
+        assert mock_data.called
+        assert mock_find_pattern.called
+        assert mock_add_key.called
+        assert result == {}

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -224,7 +224,7 @@ class TestClassCacheAPI:
         assert result == {}
 
     def test_remove_cache_dir_from_disk_and_dir_exists(self, mocker, cache_api_cls, mock_get_cache_dir):
-        mock_exists_dir = mocker.patch.object(CacheAPI, 'exists_dir', return_value=True)
+        mock_exists_dir = mocker.patch('os.path.exists', return_value=True)
         mock_rmtree = mocker.patch('shutil.rmtree')
 
         cache_api_cls.remove_cache_dir_from_disk()
@@ -234,7 +234,7 @@ class TestClassCacheAPI:
         assert mock_rmtree.called
 
     def test_remove_cache_dir_from_disk_and_dir_not_exists(self, mocker, cache_api_cls, mock_get_cache_dir):
-        mock_exists_dir = mocker.patch.object(CacheAPI, 'exists_dir', return_value=False)
+        mock_exists_dir = mocker.patch('os.path.exists', return_value=False)
         mock_rmtree = mocker.patch('shutil.rmtree')
 
         cache_api_cls.remove_cache_dir_from_disk()

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -154,20 +154,24 @@ class TestClassCacheAPI:
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 
-    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file',
-                             [(True, False, False),
-                              (False, True, False),
-                              (False, False, True),
-                              (False, True, True)])
-    def test_run(self, mocker, cache_api_cls, mock_get_cache_dir, mock_get_cache_filename, call_query, call_rm_cache_dir, call_rm_cache_file):
+    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache',
+                             [(True, False, False, False),
+                              (False, True, False, False),
+                              (False, False, True, False),
+                              (False, False, False, True),
+                              (False, True, True, False)])
+    def test_run(self, mocker, cache_api_cls, mock_get_cache_dir, mock_get_cache_filename,
+                 call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache):
         mock_query = mocker.patch.object(CacheAPI, 'get_matching_metadata_from_cache',
                                          return_value=('some', 'vals'))
         mock_remove_cache_dir = mocker.patch.object(CacheAPI, 'remove_cache_dir_from_disk')
         mock_remove_cache_file = mocker.patch.object(CacheAPI, 'remove_cache_file_from_disk')
+        mock_reset_cache = mocker.patch.object(CacheAPI, 'reset_cache_file')
 
         if not call_query: cache_api_cls.query = ()
         cache_api_cls.delete_cache_dir = call_rm_cache_dir
         cache_api_cls.delete_cache_file = call_rm_cache_file
+        cache_api_cls.reset_cache = call_reset_cache
         result = cache_api_cls.run()
 
         if call_query:
@@ -177,6 +181,7 @@ class TestClassCacheAPI:
         assert mock_get_cache_dir.called == call_rm_cache_dir
         assert mock_remove_cache_file.called == call_rm_cache_file
         assert mock_get_cache_filename.called == call_rm_cache_file
+        assert mock_reset_cache.called == call_reset_cache
 
     def test_get_matching_metadata_from_cache_and_return_some_patterns(self, mocker, cache_api_cls):
         def side_effect(pattern):

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -8,23 +8,91 @@ import pytest
 from dbcollection.core.api.cache import cache, CacheAPI
 
 
+@pytest.fixture()
+def mocks_init_class(mocker):
+    mock_cache = mocker.patch.object(CacheAPI, "get_cache_manager", return_value=True)
+    return [mock_cache]
+
+
+def assert_mock_call(mocks):
+    for mock in mocks:
+        assert mock.called
+
+
+@pytest.fixture()
+def test_data():
+    return {
+        "query": ('some_task', 'some_dataset'),
+        "delete_cache": False,
+        "delete_cache_dir": True,
+        "delete_cache_file": True,
+        "reset_cache": False,
+        "reset_path_cache": True,
+        "reset_path_downloads": True,
+        "set_cache_dir": '/some/dir/cache',
+        "set_downloads_dir": '/some/dir/cache/downloads',
+        "verbose": True
+    }
+
+
 class TestCallCache:
     """Unit tests for the core api cache method."""
 
-    def test_call_with_all_input_args(self, mocker):
-        pass
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(CacheAPI, "run")
 
-    def test_call_with_named_input_args(self, mocker):
-        pass
+        cache(test_data["query"],
+              test_data["delete_cache"],
+              test_data["delete_cache_dir"],
+              test_data["delete_cache_file"],
+              test_data["reset_cache"],
+              test_data["reset_path_cache"],
+              test_data["reset_path_downloads"],
+              test_data["set_cache_dir"],
+              test_data["set_downloads_dir"],
+              test_data["verbose"])
 
-    def test_call_without_optional_input_args(self, mocker):
-        pass
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
 
-    def test_call__raises_error_no_input_args(self, mocker):
-        pass
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(CacheAPI, "run")
 
-    def test_call__raises_error_too_many_args(self, mocker):
-        pass
+        cache(query=test_data["query"],
+              delete_cache=test_data["delete_cache"],
+              delete_cache_dir=test_data["delete_cache_dir"],
+              delete_cache_file=test_data["delete_cache_file"],
+              reset_cache=test_data["reset_cache"],
+              reset_path_cache=test_data["reset_path_cache"],
+              reset_path_downloads=test_data["reset_path_downloads"],
+              set_cache_dir=test_data["set_cache_dir"],
+              set_downloads_dir=test_data["set_downloads_dir"],
+              verbose=test_data["verbose"])
+
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
+
+    def test_call_without_optional_input_args(self, mocker, mocks_init_class):
+        mock_run = mocker.patch.object(CacheAPI, "run")
+
+        cache()
+
+        assert_mock_call(mocks_init_class)
+        assert mock_run.called
+
+    def test_call__raises_error_too_many_args(self, mocker, test_data):
+        with pytest.raises(TypeError):
+            cache(test_data["query"],
+                  test_data["delete_cache"],
+                  test_data["delete_cache_dir"],
+                  test_data["delete_cache_file"],
+                  test_data["reset_cache"],
+                  test_data["reset_path_cache"],
+                  test_data["reset_path_downloads"],
+                  test_data["set_cache_dir"],
+                  test_data["set_downloads_dir"],
+                  test_data["verbose"],
+                  'extra_input')
 
 
 class TestClassCacheAPI:

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -154,34 +154,39 @@ class TestClassCacheAPI:
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 
-    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache',
-                             [(True, False, False, False),
-                              (False, True, False, False),
-                              (False, False, True, False),
-                              (False, False, False, True),
-                              (False, True, True, False)])
+    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache, call_reset_cache_path',
+                             [(True, False, False, False, False),
+                              (False, True, False, False, False),
+                              (False, False, True, False, False),
+                              (False, False, False, True, False),
+                              (False, False, False, False, True),
+                              (False, True, True, False, False)])
     def test_run(self, mocker, cache_api_cls, mock_get_cache_dir, mock_get_cache_filename,
-                 call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache):
+                 call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache,
+                 call_reset_cache_path):
         mock_query = mocker.patch.object(CacheAPI, 'get_matching_metadata_from_cache',
                                          return_value=('some', 'vals'))
         mock_remove_cache_dir = mocker.patch.object(CacheAPI, 'remove_cache_dir_from_disk')
         mock_remove_cache_file = mocker.patch.object(CacheAPI, 'remove_cache_file_from_disk')
         mock_reset_cache = mocker.patch.object(CacheAPI, 'reset_cache_file')
+        mock_reset_cache_path = mocker.patch.object(CacheAPI, 'reset_cache_dir_path')
 
         if not call_query: cache_api_cls.query = ()
         cache_api_cls.delete_cache_dir = call_rm_cache_dir
         cache_api_cls.delete_cache_file = call_rm_cache_file
         cache_api_cls.reset_cache = call_reset_cache
+        cache_api_cls.reset_path_cache = call_reset_cache_path
         result = cache_api_cls.run()
 
         if call_query:
             assert result == ('some', 'vals')
         assert mock_query.called == call_query
         assert mock_remove_cache_dir.called == call_rm_cache_dir
-        assert mock_get_cache_dir.called == call_rm_cache_dir
+        assert mock_get_cache_dir.called == (call_rm_cache_dir or call_reset_cache_path)
         assert mock_remove_cache_file.called == call_rm_cache_file
         assert mock_get_cache_filename.called == call_rm_cache_file
         assert mock_reset_cache.called == call_reset_cache
+        assert mock_reset_cache_path.called == call_reset_cache_path
 
     def test_get_matching_metadata_from_cache_and_return_some_patterns(self, mocker, cache_api_cls):
         def side_effect(pattern):

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -98,17 +98,35 @@ class TestCallCache:
 class TestClassCacheAPI:
     """Unit tests for the CacheAPI class."""
 
-    def test_init_with_all_input_agrstest_init_with_all_input_agrs(self, mocker):
-        pass
+    def test_init_with_all_input_agrs(self, mocker, mocks_init_class, test_data):
+        cache_api = CacheAPI(query=test_data["query"],
+                             delete_cache=test_data["delete_cache"],
+                             delete_cache_dir=test_data["delete_cache_dir"],
+                             delete_cache_file=test_data["delete_cache_file"],
+                             reset_cache=test_data["reset_cache"],
+                             reset_path_cache=test_data["reset_path_cache"],
+                             reset_path_downloads=test_data["reset_path_downloads"],
+                             set_cache_dir=test_data["set_cache_dir"],
+                             set_downloads_dir=test_data["set_downloads_dir"],
+                             verbose=test_data["verbose"])
 
-    def test_init__raises_error_no_input_args(self, mocker):
-        pass
+        assert_mock_call(mocks_init_class)
+        assert cache_api.query == test_data["query"]
+        assert cache_api.delete_cache == test_data["delete_cache"]
+        assert cache_api.delete_cache_dir == test_data["delete_cache_dir"]
+        assert cache_api.delete_cache_file == test_data["delete_cache_file"]
+        assert cache_api.reset_cache == test_data["reset_cache"]
+        assert cache_api.reset_path_cache == test_data["reset_path_cache"]
+        assert cache_api.reset_path_downloads == test_data["reset_path_downloads"]
+        assert cache_api.set_cache_dir == test_data["set_cache_dir"]
+        assert cache_api.set_downloads_dir == test_data["set_downloads_dir"]
+        assert cache_api.verbose == test_data["verbose"]
 
     def test_init__raises_error_too_many_input_args(self, mocker):
-        pass
-
-    def test_init__raises_error_missing_one_input_arg(self, mocker):
-        pass
+        with pytest.raises(TypeError):
+            CacheAPI('some_query', False, False, False, True, True, True,
+                     '/some/dir/cache', '/some/dir/cache/downloads', False,
+                     'extra field')
 
     def test_run(self, mocker):
         pass

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -154,19 +154,22 @@ class TestClassCacheAPI:
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 
-    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache, call_reset_cache_path, call_reset_download_path, call_set_cache_path',
-                             [(True, False, False, False, False, False, False),
-                              (False, True, False, False, False, False, False),
-                              (False, False, True, False, False, False, False),
-                              (False, False, False, True, False, False, False),
-                              (False, False, False, False, True, False, False),
-                              (False, False, False, False, False, True, False),
-                              (False, False, False, False, False, False, True),
-                              (False, True, True, False, False, False, False)])
+    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache, call_reset_cache_path, ' +
+                             'call_reset_download_path, call_set_cache_path, call_set_download_path', [
+                             (True, False, False, False, False, False, False, False),
+                             (False, True, False, False, False, False, False, False),
+                             (False, False, True, False, False, False, False, False),
+                             (False, False, False, True, False, False, False, False),
+                             (False, False, False, False, True, False, False, False),
+                             (False, False, False, False, False, True, False, False),
+                             (False, False, False, False, False, False, True, False),
+                             (False, False, False, False, False, False, False, True),
+                             (False, True, True, False, False, False, False, False)
+                            ])
     def test_run(self, mocker, cache_api_cls, mock_get_cache_dir, mock_get_cache_filename,
                  call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache,
                  call_reset_cache_path, call_reset_download_path,
-                 call_set_cache_path):
+                 call_set_cache_path, call_set_download_path):
         mock_query = mocker.patch.object(CacheAPI, 'get_matching_metadata_from_cache',
                                          return_value=('some', 'vals'))
         mock_remove_cache_dir = mocker.patch.object(CacheAPI, 'remove_cache_dir_from_disk')
@@ -176,6 +179,7 @@ class TestClassCacheAPI:
         mock_reset_download_path = mocker.patch.object(CacheAPI, 'reset_download_dir_path')
         mock_get_download_dir = mocker.patch.object(CacheAPI, 'get_download_dir', return_value='/some/dir/downloads')
         mock_set_cache_path = mocker.patch.object(CacheAPI, 'set_cache_dir_path')
+        mock_set_download_path = mocker.patch.object(CacheAPI, 'set_download_dir_path')
 
         if not call_query: cache_api_cls.query = ()
         cache_api_cls.delete_cache_dir = call_rm_cache_dir
@@ -184,6 +188,7 @@ class TestClassCacheAPI:
         cache_api_cls.reset_path_cache = call_reset_cache_path
         cache_api_cls.reset_path_downloads = call_reset_download_path
         if not call_set_cache_path: cache_api_cls.set_cache_dir = ''
+        if not call_set_download_path: cache_api_cls.set_downloads_dir = ''
 
         result = cache_api_cls.run()
 
@@ -197,8 +202,9 @@ class TestClassCacheAPI:
         assert mock_reset_cache.called == call_reset_cache
         assert mock_reset_cache_path.called == call_reset_cache_path
         assert mock_reset_download_path.called == call_reset_download_path
-        assert mock_get_download_dir.called == call_reset_download_path
+        assert mock_get_download_dir.called == (call_reset_download_path or call_set_download_path)
         assert mock_set_cache_path.called == call_set_cache_path
+        assert mock_set_download_path.called == call_set_download_path
 
     def test_get_matching_metadata_from_cache_and_return_some_patterns(self, mocker, cache_api_cls):
         def side_effect(pattern):

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -1,0 +1,46 @@
+"""
+Test dbcollection core API: cacbe.
+"""
+
+
+import pytest
+
+from dbcollection.core.api.cache import cache, CacheAPI
+
+
+class TestCallCache:
+    """Unit tests for the core api cache method."""
+
+    def test_call_with_all_input_args(self, mocker):
+        pass
+
+    def test_call_with_named_input_args(self, mocker):
+        pass
+
+    def test_call_without_optional_input_args(self, mocker):
+        pass
+
+    def test_call__raises_error_no_input_args(self, mocker):
+        pass
+
+    def test_call__raises_error_too_many_args(self, mocker):
+        pass
+
+
+class TestClassCacheAPI:
+    """Unit tests for the CacheAPI class."""
+
+    def test_init_with_all_input_agrstest_init_with_all_input_agrs(self, mocker):
+        pass
+
+    def test_init__raises_error_no_input_args(self, mocker):
+        pass
+
+    def test_init__raises_error_too_many_input_args(self, mocker):
+        pass
+
+    def test_init__raises_error_missing_one_input_arg(self, mocker):
+        pass
+
+    def test_run(self, mocker):
+        pass

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -154,28 +154,32 @@ class TestClassCacheAPI:
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 
-    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache, call_reset_cache_path',
-                             [(True, False, False, False, False),
-                              (False, True, False, False, False),
-                              (False, False, True, False, False),
-                              (False, False, False, True, False),
-                              (False, False, False, False, True),
-                              (False, True, True, False, False)])
+    @pytest.mark.parametrize('call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache, call_reset_cache_path, call_reset_download_path',
+                             [(True, False, False, False, False, False),
+                              (False, True, False, False, False, False),
+                              (False, False, True, False, False, False),
+                              (False, False, False, True, False, False),
+                              (False, False, False, False, True, False),
+                              (False, False, False, False, False, True),
+                              (False, True, True, False, False, False)])
     def test_run(self, mocker, cache_api_cls, mock_get_cache_dir, mock_get_cache_filename,
                  call_query, call_rm_cache_dir, call_rm_cache_file, call_reset_cache,
-                 call_reset_cache_path):
+                 call_reset_cache_path, call_reset_download_path):
         mock_query = mocker.patch.object(CacheAPI, 'get_matching_metadata_from_cache',
                                          return_value=('some', 'vals'))
         mock_remove_cache_dir = mocker.patch.object(CacheAPI, 'remove_cache_dir_from_disk')
         mock_remove_cache_file = mocker.patch.object(CacheAPI, 'remove_cache_file_from_disk')
         mock_reset_cache = mocker.patch.object(CacheAPI, 'reset_cache_file')
         mock_reset_cache_path = mocker.patch.object(CacheAPI, 'reset_cache_dir_path')
+        mock_reset_download_path = mocker.patch.object(CacheAPI, 'reset_download_dir_path')
+        mock_get_download_dir = mocker.patch.object(CacheAPI, 'get_download_dir', return_value='/some/dir/downlaods')
 
         if not call_query: cache_api_cls.query = ()
         cache_api_cls.delete_cache_dir = call_rm_cache_dir
         cache_api_cls.delete_cache_file = call_rm_cache_file
         cache_api_cls.reset_cache = call_reset_cache
         cache_api_cls.reset_path_cache = call_reset_cache_path
+        cache_api_cls.reset_path_downloads = call_reset_download_path
         result = cache_api_cls.run()
 
         if call_query:
@@ -187,6 +191,8 @@ class TestClassCacheAPI:
         assert mock_get_cache_filename.called == call_rm_cache_file
         assert mock_reset_cache.called == call_reset_cache
         assert mock_reset_cache_path.called == call_reset_cache_path
+        assert mock_reset_download_path.called == call_reset_download_path
+        assert mock_get_download_dir.called == call_reset_download_path
 
     def test_get_matching_metadata_from_cache_and_return_some_patterns(self, mocker, cache_api_cls):
         def side_effect(pattern):

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -22,7 +22,7 @@ def assert_mock_call(mocks):
 @pytest.fixture()
 def test_data():
     return {
-        "query": ('some_task', 'some_dataset'),
+        "query": 'some_task',
         "delete_cache": False,
         "delete_cache_dir": True,
         "delete_cache_file": True,
@@ -99,7 +99,7 @@ class TestClassCacheAPI:
     """Unit tests for the CacheAPI class."""
 
     def test_init_with_all_input_agrs(self, mocker, mocks_init_class, test_data):
-        cache_api = CacheAPI(query=test_data["query"],
+        cache_api = CacheAPI(query=(test_data["query"],),
                              delete_cache=test_data["delete_cache"],
                              delete_cache_dir=test_data["delete_cache_dir"],
                              delete_cache_file=test_data["delete_cache_file"],
@@ -111,7 +111,7 @@ class TestClassCacheAPI:
                              verbose=test_data["verbose"])
 
         assert_mock_call(mocks_init_class)
-        assert cache_api.query == test_data["query"]
+        assert cache_api.query == (test_data["query"],)
         assert cache_api.delete_cache == test_data["delete_cache"]
         assert cache_api.delete_cache_dir == test_data["delete_cache_dir"]
         assert cache_api.delete_cache_file == test_data["delete_cache_file"]
@@ -124,7 +124,7 @@ class TestClassCacheAPI:
 
     def test_init__raises_error_too_many_input_args(self, mocker):
         with pytest.raises(TypeError):
-            CacheAPI('some_query', False, False, False, True, True, True,
+            CacheAPI(('some_query',), False, False, False, True, True, True,
                      '/some/dir/cache', '/some/dir/cache/downloads', False,
                      'extra field')
 

--- a/dbcollection/tests/utils/test_utils.py
+++ b/dbcollection/tests/utils/test_utils.py
@@ -1,0 +1,38 @@
+"""
+Test dbcollection utils.
+"""
+
+
+import pytest
+
+from dbcollection.utils import nested_lookup
+
+
+class TestNestedLookup:
+    """Unit tests for the nested_lookup method."""
+
+    @pytest.mark.parametrize(
+        "key, data, expected",
+        [('keyA', {"keyA": 'valA', "keyB": {"keyA": 'valC'}}, ['valA', 'valC']),
+         ('keyB', {"keyA": 'valA', "keyB": {"keyA": 'valC'}}, [{"keyA": 'valC'}]),
+         ('keyC', {"keyA": 'valA', "keyB": {"keyA": 'valC'}}, [])]
+    )
+    def test_retrieve_values_from_key(self, key, data, expected):
+        result = list(nested_lookup(key, data))
+
+        assert sorted(result) == sorted(expected)
+
+    def test_retrieve_values_from_key_case_insensitive(self):
+        data = {'first_name': 'jose', 'second_NAME': 'lopes'}
+
+        result = list(nested_lookup('name', data, True))
+
+        assert sorted(result) == ['jose', 'lopes']
+
+    def test_raises_error_missing_input_args(self):
+        with pytest.raises(TypeError):
+            nested_lookup()
+
+    def test_raises_error_missing_one_input_args(self):
+        with pytest.raises(TypeError):
+            nested_lookup('some_key')

--- a/dbcollection/utils/__init__.py
+++ b/dbcollection/utils/__init__.py
@@ -7,6 +7,7 @@ Also, all third-party submodules are located under this module.
 
 
 from __future__ import print_function
+from six import iteritems
 
 
 def print_text_box(text):
@@ -27,14 +28,41 @@ def print_text_box(text):
 
 
 def nested_lookup(key, document, wild=False):
-    """Lookup a key in a nested document recursively and yields a value."""
+    """Lookup a key in a nested document recursively and yields a value.
+
+    Parameters
+    ----------
+    key : str
+        Key string to be found.
+    document : dict/list
+        List or dictionary to be searched.
+    wild : bool, optional
+        Exact key search (True) or case insensitive search (False).
+
+    Returns
+    -------
+    List
+        List of matching values / patterns.
+
+    Examples
+    --------
+    Return all values from a dictionary that contain
+    the key 'email'.
+
+    >>> from dbcollection.utils import nested_lookup
+    >>> nested_lookup('email', {'first_email': 'myemail@gmail.com', 'second_email': 'another@gmail.com'})
+    ['myemail@gmail.com', 'another@gmail.com']
+
+    """
+    assert key, "Must input a valid key."
+    assert document, "Must input a valid dictionary."
     if isinstance(document, list):
         for d in document:
             for result in nested_lookup(key, d, wild=wild):
                 yield result
 
     if isinstance(document, dict):
-        for k, v in document:
+        for k, v in iteritems(document):
             if key == k or (wild and key.lower() in k.lower()):
                 yield v
             elif isinstance(v, dict):

--- a/dbcollection/utils/__init__.py
+++ b/dbcollection/utils/__init__.py
@@ -24,3 +24,23 @@ def print_text_box(text):
     str_separator = '-' * len(str_display)
     print('\n{separator}\n{text}\n{separator}\n'
           .format(separator=str_separator, text=str_display))
+
+
+def nested_lookup(key, document, wild=False):
+    """Lookup a key in a nested document recursively and yields a value."""
+    if isinstance(document, list):
+        for d in document:
+            for result in nested_lookup(key, d, wild=wild):
+                yield result
+
+    if isinstance(document, dict):
+        for k, v in document:
+            if key == k or (wild and key.lower() in k.lower()):
+                yield v
+            elif isinstance(v, dict):
+                for result in nested_lookup(key, v, wild=wild):
+                    yield result
+            elif isinstance(v, list):
+                for d in v:
+                    for result in nested_lookup(key, d, wild=wild):
+                        yield result

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal=1
 description-file = README.md
 
 [flake8]
-max-line-length = 100
+max-line-length = 120
 ignore = E305,E402,E721,F401,F403,F405,F821,F841,F999
 exclude =
     .tox,


### PR DESCRIPTION
This PR addresses #101 and merges the `config_cache()` and `query()` methods into a new method: `cache()`. This simplifies the core api by grouping related functionality under a single method.

The new `cache()` method does not allow modification of values using a key + pattern. Instead, the advised strategy is to use `CacheManager` object or modify the `dbcollection.json` file manually. 

> Note: the **reset** and **delete** functionality remains the same as before.

Additional functionality has been added:

- query the cache for a particular pattern by using a string or list of strings via the `query` input arg
- set the cache's directory path by introducing a new path via the `set_cache_dir` input arg
- set the download's directory path by introducing a new path via the `set_downloads_dir` input arg