### PR TITLE
[Refactor] improve api tests

### DIFF
--- a/dbcollection/core/api/add.py
+++ b/dbcollection/core/api/add.py
@@ -43,9 +43,6 @@ def add(name, task, data_dir, hdf5_filename, categories=(), verbose=True, force_
     assert task, "Must input a valid task."
     assert data_dir, "Must input a valid data_dir."
     assert hdf5_filename, "Must input a valid file_path."
-    assert isinstance(categories, (list, tuple, str)), "Must input valid categories."
-    assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
-    assert isinstance(force_overwrite, bool), "Must input a valid boolean for force_overwrite."
 
     if isinstance(categories, str):
         categories = (categories,)
@@ -109,10 +106,10 @@ class AddAPI(object):
 
     def __init__(self, name, task, data_dir, hdf5_filename, categories, verbose, force_overwrite):
         """Initialize class."""
-        assert name, "Must input a valid name."
-        assert task, "Must input a valid task."
-        assert data_dir, "Must input a valid data_dir."
-        assert hdf5_filename, "Must input a valid file_path."
+        assert isinstance(name, str), "Must input a valid name."
+        assert isinstance(task, str), "Must input a valid task."
+        assert isinstance(data_dir, str), "Must input a valid data_dir."
+        assert isinstance(hdf5_filename, str), "Must input a valid file_path."
         assert isinstance(categories, tuple), "Must input a valid list(tuple) of categories."
         assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
         assert isinstance(force_overwrite, bool), "Must input a valid boolean for force_overwrite."

--- a/dbcollection/core/api/cache.py
+++ b/dbcollection/core/api/cache.py
@@ -71,8 +71,10 @@ def cache(query=(), delete_cache=False, delete_cache_dir=False, delete_cache_fil
     """
     if isinstance(query, str):
         query = (query, )
+    else:
+        query = tuple(query)
 
-    cache = CacheAPI(query=tuple(query),
+    cache = CacheAPI(query=query,
                      delete_cache=delete_cache,
                      delete_cache_dir=delete_cache_dir,
                      delete_cache_file=delete_cache_file,
@@ -177,12 +179,10 @@ class CacheAPI(object):
         """Main method."""
         if any(self.query):
             result = self.get_matching_metadata_from_cache(self.query)
-
             if self.verbose:
                 print('==> Patterns found in cache:')
                 for i, pattern in enumerate(self.query):
                     print('    - {}: {} found'.format(pattern, len(result[i])))
-
             return result
 
         if self.delete_cache_dir or self.delete_cache:

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -118,14 +118,9 @@ class DownloadAPI(object):
 
     def download_dataset(self):
         """Download the dataset to disk."""
-        constructor = self.get_dataset_constructor()
-        save_data_dir = self.get_download_data_dir()
-        save_cache_dir = self.get_download_cache_dir()
-        db = constructor(data_path=save_data_dir,
-                         cache_path=save_cache_dir,
-                         extract_data=self.extract_data,
-                         verbose=self.verbose)
-        db.download()
+        data_dir = self.get_download_data_dir()
+        cache_dir = self.get_download_cache_dir()
+        self.download_dataset_files(data_dir, cache_dir)
 
     def get_dataset_constructor(self):
         db_metadata = self.get_dataset_metadata_obj(self.name)
@@ -165,6 +160,14 @@ class DownloadAPI(object):
 
     def get_cache_dir(self):
         return self.cache_manager.manager.cache_dir
+
+    def download_dataset_files(self, data_dir, cache_dir):
+        constructor = self.get_dataset_constructor()
+        db = constructor(data_path=data_dir,
+                         cache_path=cache_dir,
+                         extract_data=self.extract_data,
+                         verbose=self.verbose)
+        db.download()
 
     def update_cache(self):
         """Update the cache manager information for this dataset."""

--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -85,7 +85,7 @@ class DownloadAPI(object):
 
     def __init__(self, name, data_dir, extract_data, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name.'
+        assert isinstance(name, str), 'Must input a valid dataset name.'
         assert isinstance(data_dir, str), 'Must input a valid directory.'
         assert isinstance(extract_data, bool), "Must input a valid boolean for extract_data."
         assert isinstance(verbose, bool), "Must input a valid boolean for verbose."

--- a/dbcollection/core/api/info.py
+++ b/dbcollection/core/api/info.py
@@ -69,14 +69,20 @@ def info(by_dataset=(), by_task=(), by_category=(),
     """
     if isinstance(by_dataset, str):
         by_dataset = (by_dataset, )
+    else:
+        by_dataset = tuple(by_dataset)
     if isinstance(by_task, str):
         by_task = (by_task, )
+    else:
+        by_task = tuple(by_task)
     if isinstance(by_category, str):
         by_category = (by_category, )
+    else:
+        by_category = tuple(by_category)
 
-    db_info = InfoAPI(by_dataset=tuple(by_dataset),
-                      by_task=tuple(by_task),
-                      by_category=tuple(by_category),
+    db_info = InfoAPI(by_dataset=by_dataset,
+                      by_task=by_task,
+                      by_category=by_category,
                       show_info=show_info,
                       show_datasets=show_datasets,
                       show_categories=show_categories,
@@ -169,16 +175,13 @@ class InfoAPI(object):
         if self.show_system or self.show_available:
             if self.show_system:
                 self.display_registered_datasets_in_cache()
-
             if self.show_available:
                 self.display_available_datasets_supported_by_dbcollection()
         else:
             if self.show_info:
                 self.display_info_section_from_cache()
-
             if self.show_datasets:
                 self.display_dataset_section_from_cache()
-
             if self.show_categories:
                 self.display_category_section_from_cache()
 

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -98,27 +98,27 @@ class LoadAPI(object):
 
     def __init__(self, name, task, data_dir, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name: {}'.format(name)
-        assert task, 'Must input a valid task name: {}'.format(task)
-        assert data_dir is not None, 'Must input a valid directory path: {}'.format(data_dir)
-        assert verbose is not None, 'verbose cannot be empty'
+        assert isinstance(name, str), 'Must input a valid dataset name.'
+        assert isinstance(task, str), 'Must input a valid task name.'
+        assert isinstance(data_dir, str), 'Must input a valid directory.'
+        assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
 
         self.name = name
         self.data_dir = data_dir
         self.verbose = verbose
         self.cache_manager = self.get_cache_manager()
-        self.db_metadata = self.get_dataset_metadata_obj(name)
         self.task = self.parse_task_name(task)
 
     def get_cache_manager(self):
         return CacheManager()
 
-    def get_dataset_metadata_obj(self, name):
-        return MetadataConstructor(name)
-
     def parse_task_name(self, task):
         """Validate the task name."""
-        return self.db_metadata.parse_task_name(task)
+        db_metadata = self.get_dataset_metadata_obj(self.name)
+        return db_metadata.parse_task_name(task)
+
+    def get_dataset_metadata_obj(self, name):
+        return MetadataConstructor(name)
 
     def run(self):
         """Main method."""
@@ -182,16 +182,20 @@ class LoadAPI(object):
         return data_loader
 
     def get_data_dir_path_from_cache(self):
-        dataset_metadata = self.cache_manager.dataset.get(self.name)
+        dataset_metadata = self.get_dataset_metadata(self.name)
         return dataset_metadata["data_dir"]
 
+    def get_dataset_metadata(self, name):
+        return self.cache_manager.dataset.get(name)
+
     def get_hdf5_file_path_from_cache(self):
-        task_metadata = self.cache_manager.task.get(self.name, self.task)
+        task_metadata = self.get_task_metadata(self.name, self.task)
         return task_metadata["filename"]
 
+    def get_task_metadata(self, name, task):
+        return self.cache_manager.task.get(name, task)
+
     def get_loader_obj(self, data_dir, hdf5_filepath):
-        assert data_dir
-        assert hdf5_filepath
         return DataLoader(name=self.name,
                           task=self.task,
                           data_dir=data_dir,

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -32,13 +32,14 @@ def process(name, task='default', verbose=True):
 
     Examples
     --------
+    >>> import dbcollection as dbc
+
     Download the CIFAR10 dataset to disk.
 
-    >>> import dbcollection as dbc
     >>> dbc.process('cifar10', task='classification', verbose=False)
 
     """
-    assert name, 'Must input a valid dataset name: {}'.format(name)
+    assert name, 'Must input a valid dataset name.'
 
     processer = ProcessAPI(name=name,
                            task=task,
@@ -75,8 +76,6 @@ class ProcessAPI(object):
         Flag to extract data (if True).
     cache_manager : CacheManager
         Cache manager object.
-    db_metadata : MetadataConstructor
-        Dataset metadata/constructor manager.
 
     Raises
     ------
@@ -87,70 +86,24 @@ class ProcessAPI(object):
 
     def __init__(self, name, task, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name: {}'.format(name)
-        assert task is not None, 'Must input a valid task name: {}'.format(task)
-        assert verbose is not None, 'verbose cannot be empty'
+        assert name, 'Must input a valid dataset name.'
+        assert isinstance(task, str), 'Must input a valid task name.'
+        assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
 
         self.name = name
+        self.task = task
         self.verbose = verbose
         self.extract_data = False
         self.cache_manager = self.get_cache_manager()
-        self.db_metadata = self.get_dataset_metadata_obj(name)
-        self.task = self.parse_task_name(task)
-        self.check_if_task_exists_in_database()
-
-        self.save_data_dir = self.get_dataset_data_dir_path()
-        self.save_cache_dir = self.get_dataset_cache_dir_path()
 
     def get_cache_manager(self):
         return CacheManager()
-
-    def get_dataset_metadata_obj(self, name):
-        return MetadataConstructor(name)
-
-    def parse_task_name(self, task):
-        """Parse the input task string."""
-        if task == '':
-            task_parsed = self.get_default_task()
-        elif task == 'default':
-            task_parsed = self.get_default_task()
-        else:
-            task_parsed = task
-        return task_parsed
-
-    def get_default_task(self):
-        """Returns the default task for this dataset."""
-        return self.db_metadata.get_default_task()
-
-    def check_if_task_exists_in_database(self):
-        """Check if task exists in the list of available tasks for processing."""
-        if not self.exists_task():
-            raise KeyError('The task \'{}\' does not exists for loading/processing.'
-                           .format(self.task))
-
-    def exists_task(self):
-        """Checks if a task exists for a dataset."""
-        return self.task in self.db_metadata.get_tasks()
-
-    def get_dataset_data_dir_path(self):
-        dataset_data_cache = self.get_dataset_metadata_from_cache()
-        return dataset_data_cache['data_dir']
-
-    def get_dataset_metadata_from_cache(self):
-        return self.cache_manager.dataset.get(self.name)
-
-    def get_dataset_cache_dir_path(self):
-        cache_dir = self.get_cache_dir_path_from_cache()
-        return os.path.join(cache_dir, self.name)
-
-    def get_cache_dir_path_from_cache(self):
-        return self.cache_manager.info.cache_dir
 
     def run(self):
         """Main method."""
         if self.verbose:
             print('==> Setup directories to store the data files.')
-        self.create_dir(self.save_cache_dir)
+        self.set_dirs_processed_metadata()
 
         if self.verbose:
             print('==> Process \'{}\' metadata to disk...'.format(self.name))
@@ -163,6 +116,17 @@ class ProcessAPI(object):
         if self.verbose:
             print('==> Dataset processing complete.')
 
+    def set_dirs_processed_metadata(self):
+        cache_dir = self.get_dataset_cache_dir_path()
+        self.create_dir(cache_dir)
+
+    def get_dataset_cache_dir_path(self):
+        cache_dir = self.get_cache_dir_path_from_cache()
+        return os.path.join(cache_dir, self.name)
+
+    def get_cache_dir_path_from_cache(self):
+        return self.cache_manager.info.cache_dir
+
     def create_dir(self, path):
         """Create a directory in the disk."""
         if not os.path.exists(path):
@@ -171,18 +135,60 @@ class ProcessAPI(object):
     def process_dataset(self):
         """Process the dataset's metadata."""
         constructor = self.get_dataset_constructor()
-        db = constructor(data_path=self.save_data_dir,
-                         cache_path=self.save_cache_dir,
+        save_data_dir = self.get_dataset_data_dir_path()
+        save_cache_dir = self.get_dataset_cache_dir_path()
+        db = constructor(data_path=save_data_dir,
+                         cache_path=save_cache_dir,
                          extract_data=self.extract_data,
                          verbose=self.verbose)
-        task_info = db.process(self.task)
+        task = self.parse_task_name(self.task)
+        self.check_if_task_exists_in_database(task)
+        task_info = db.process(task)
         return task_info
 
     def get_dataset_constructor(self):
-        return self.db_metadata.get_constructor()
+        db_metadata = self.get_dataset_metadata_obj(self.name)
+        constructor = db_metadata.get_constructor()
+        return constructor
+
+    def get_dataset_metadata_obj(self, name):
+        return MetadataConstructor(name)
+
+    def get_dataset_data_dir_path(self):
+        dataset_metadata = self.get_dataset_metadata_from_cache()
+        return dataset_metadata['data_dir']
+
+    def get_dataset_metadata_from_cache(self):
+        return self.cache_manager.dataset.get(self.name)
+
+    def parse_task_name(self, task):
+        """Parse the input task string."""
+        if task == '' or task == 'default':
+            task_parsed = self.get_default_task()
+        else:
+            task_parsed = task
+        return task_parsed
+
+    def get_default_task(self):
+        """Returns the default task for this dataset."""
+        db_metadata = self.get_dataset_metadata_obj(self.name)
+        default_task = db_metadata.get_default_task()
+        return default_task
+
+    def check_if_task_exists_in_database(self, task):
+        """Check if task exists in the list of available tasks for processing."""
+        if not self.exists_task(task):
+            raise KeyError('The task \'{}\' does not exists for loading/processing.'
+                           .format(self.task))
+
+    def exists_task(self, task):
+        """Checks if a task exists for a dataset."""
+        db_metadata = self.get_dataset_metadata_obj(self.name)
+        return task in db_metadata.get_tasks()
 
     def update_cache(self, task_info):
         """Update the cache manager information for this dataset."""
+        cache_dir = self.get_dataset_cache_dir_path()
         self.cache_manager.dataset.update(name=self.name,
-                                          cache_dir=self.save_cache_dir,
+                                          cache_dir=cache_dir,
                                           tasks=task_info)

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -86,7 +86,7 @@ class ProcessAPI(object):
 
     def __init__(self, name, task, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name.'
+        assert isinstance(name, str), 'Must input a valid dataset name.'
         assert isinstance(task, str), 'Must input a valid task name.'
         assert isinstance(verbose, bool), "Must input a valid boolean for verbose."
 

--- a/dbcollection/core/api/process.py
+++ b/dbcollection/core/api/process.py
@@ -134,17 +134,11 @@ class ProcessAPI(object):
 
     def process_dataset(self):
         """Process the dataset's metadata."""
-        constructor = self.get_dataset_constructor()
-        save_data_dir = self.get_dataset_data_dir_path()
-        save_cache_dir = self.get_dataset_cache_dir_path()
-        db = constructor(data_path=save_data_dir,
-                         cache_path=save_cache_dir,
-                         extract_data=self.extract_data,
-                         verbose=self.verbose)
+        data_dir = self.get_dataset_data_dir_path()
+        cache_dir = self.get_dataset_cache_dir_path()
         task = self.parse_task_name(self.task)
         self.check_if_task_exists_in_database(task)
-        task_info = db.process(task)
-        return task_info
+        return self.process_dataset_metadata(data_dir, cache_dir, task)
 
     def get_dataset_constructor(self):
         db_metadata = self.get_dataset_metadata_obj(self.name)
@@ -185,6 +179,15 @@ class ProcessAPI(object):
         """Checks if a task exists for a dataset."""
         db_metadata = self.get_dataset_metadata_obj(self.name)
         return task in db_metadata.get_tasks()
+
+    def process_dataset_metadata(self, data_dir, cache_dir, task):
+        constructor = self.get_dataset_constructor()
+        db = constructor(data_path=data_dir,
+                         cache_path=cache_dir,
+                         extract_data=self.extract_data,
+                         verbose=self.verbose)
+        task_info = db.process(task)
+        return task_info
 
     def update_cache(self, task_info):
         """Update the cache manager information for this dataset."""

--- a/dbcollection/core/api/remove.py
+++ b/dbcollection/core/api/remove.py
@@ -91,7 +91,7 @@ class RemoveAPI(object):
 
     def __init__(self, name, task, delete_data, verbose):
         """Initialize class."""
-        assert name, 'Must input a valid dataset name.'
+        assert isinstance(name, str), 'Must input a valid dataset name.'
         assert isinstance(task, str), 'Must input a valid task name.'
         assert isinstance(delete_data, bool), "Must input a valid boolean for delete_data."
         assert isinstance(verbose, bool), "Must input a valid boolean for verbose."

--- a/dbcollection/tests/core/api/test_add.py
+++ b/dbcollection/tests/core/api/test_add.py
@@ -35,7 +35,7 @@ def test_data():
 class TestCallAdd:
     """Unit tests for the core api add method."""
 
-    def test_call(self, mocker, mocks_init_class, test_data):
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(AddAPI, "run")
 
         add(test_data['dataset'],
@@ -49,7 +49,7 @@ class TestCallAdd:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call_with_named_args(self, mocker, mocks_init_class, test_data):
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(AddAPI, "run")
 
         add(name=test_data['dataset'],
@@ -63,7 +63,7 @@ class TestCallAdd:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call_without_optional_inputs(self, mocker, mocks_init_class, test_data):
+    def test_call_without_optional_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(AddAPI, "run")
 
         add(test_data['dataset'], test_data['task'], test_data['data_dir'], test_data['hdf5_filename'])
@@ -71,11 +71,11 @@ class TestCallAdd:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call__raises_error_missing_inputs(self, mocker):
+    def test_call__raises_error_no_inputs(self, mocker):
         with pytest.raises(TypeError):
             add("db", "task", "data dir")
 
-    def test_call__raises_error_too_many_inputs(self, mocker):
+    def test_call__raises_error_extra_inputs(self, mocker):
         with pytest.raises(TypeError):
             add("db", "task", "data dir", "filename", [], False, False, 'extra field')
 
@@ -96,7 +96,7 @@ def add_api_cls(mocker, mocks_init_class, test_data):
 class TestClassAddAPI:
     """Unit tests for the AddAPI class."""
 
-    def test_init_with_all_inputs(self, mocker, mocks_init_class, test_data):
+    def test_init_with_all_input_args(self, mocker, mocks_init_class, test_data):
         add_api = AddAPI(name=test_data['dataset'],
                          task=test_data['task'],
                          data_dir=test_data['data_dir'],
@@ -114,15 +114,15 @@ class TestClassAddAPI:
         assert add_api.verbose == test_data['verbose']
         assert add_api.force_overwrite == test_data['force_overwrite']
 
-    def test_init__raises_error_missing_inputs(self, mocker):
+    def test_init__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
             AddAPI()
 
-    def test_init__raises_error_too_many_inputs(self, mocker):
+    def test_init__raises_error_too_many_input_args(self, mocker):
         with pytest.raises(TypeError):
             AddAPI("db", "task", "data dir", "filename", [], False, True, 'extra field')
 
-    def test_init__raises_error_missing_one_input(self, mocker):
+    def test_init__raises_error_missing_one_input_arg(self, mocker):
         with pytest.raises(TypeError):
             AddAPI("db", "data dir", "filename", [], False, True)
 

--- a/dbcollection/tests/core/api/test_cache.py
+++ b/dbcollection/tests/core/api/test_cache.py
@@ -124,7 +124,7 @@ def mock_get_cache_filename(mocker):
 class TestClassCacheAPI:
     """Unit tests for the CacheAPI class."""
 
-    def test_init_with_all_input_agrs(self, mocker, mocks_init_class, test_data):
+    def test_init_with_all_input_args(self, mocker, mocks_init_class, test_data):
         cache_api = CacheAPI(query=(test_data["query"],),
                              delete_cache=test_data["delete_cache"],
                              delete_cache_dir=test_data["delete_cache_dir"],

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -3,6 +3,7 @@ Test dbcollection core API: download.
 """
 
 
+import os
 import pytest
 
 from dbcollection.core.api.download import download, DownloadAPI
@@ -11,9 +12,7 @@ from dbcollection.core.api.download import download, DownloadAPI
 @pytest.fixture()
 def mocks_init_class(mocker):
     mock_cache = mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
-    mock_data_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/path/to/cache/downloads/')
-    mock_cache_dir = mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
-    return [mock_cache, mock_data_dir, mock_cache_dir]
+    return [mock_cache]
 
 
 def assert_mock_init_class(mocks):
@@ -21,12 +20,14 @@ def assert_mock_init_class(mocks):
         assert mock.called
 
 
-def test_db_data():
-    dataset = 'mnist'
-    data_dir = '/some/dir/path/'
-    extract_data = True
-    verbose = False
-    return dataset, data_dir, extract_data, verbose
+@pytest.fixture()
+def test_data():
+    return {
+        "dataset": 'mnist',
+        "data_dir": '/some/dir/path/',
+        "extract_data": True,
+        "verbose": False
+    }
 
 
 class TestCallDownload:
@@ -34,24 +35,35 @@ class TestCallDownload:
 
     def test_call_with_dataset_name(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
-        dataset = 'mnist'
 
-        download(dataset)
+        download("some_dataset")
 
         assert_mock_init_class(mocks_init_class)
         assert mock_run.called
 
-    def test_call_all_parameters(self, mocker, mocks_init_class):
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(DownloadAPI, "run")
-        dataset = 'mnist'
-        _, data_dir, extract_data, verbose = test_db_data()
 
-        download(dataset, data_dir, extract_data, verbose)
+        download(test_data["dataset"],
+                 test_data["data_dir"],
+                 test_data["extract_data"],
+                 test_data["verbose"])
 
         assert_mock_init_class(mocks_init_class)
         assert mock_run.called
 
-    def test_call__raise_error_missing_inputs(self, mocker, mocks_init_class):
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(DownloadAPI, "run")
+
+        download(name=test_data["dataset"],
+                 data_dir=test_data["data_dir"],
+                 extract_data=test_data["extract_data"],
+                 verbose=test_data["verbose"])
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+
+    def test_call__raises_error_no_input_args(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
 
         with pytest.raises(TypeError):
@@ -59,91 +71,161 @@ class TestCallDownload:
 
     def test_call__raise_error_invalid_dataset_name(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(DownloadAPI, "run")
-        dataset = None
 
         with pytest.raises(AssertionError):
-            download(dataset)
+            download(None)
+
+    def test_call__raises_error_too_many_args(self, mocker):
+        with pytest.raises(TypeError):
+            download('some_dataset', '/some/dir/path', True, True, 'extra_field')
+
+
+@pytest.fixture()
+def download_api_cls(mocker, mocks_init_class, test_data):
+    return DownloadAPI(
+        name=test_data['dataset'],
+        data_dir=test_data['data_dir'],
+        extract_data=test_data['extract_data'],
+        verbose=test_data['verbose']
+    )
 
 
 class TestClassDownloadAPI:
     """Unit tests for the DownloadAPI class."""
 
-    def test_init_with_all_inputs(self, mocker, mocks_init_class):
-        dataset, data_dir, extract_data, verbose = test_db_data()
-
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
+    def test_init_with_all_input_args(self, mocker, mocks_init_class, test_data):
+        download_cls = DownloadAPI(name=test_data["dataset"],
+                                   data_dir=test_data["data_dir"],
+                                   extract_data=test_data["extract_data"],
+                                   verbose=test_data["verbose"])
 
         assert_mock_init_class(mocks_init_class)
-        assert download_cls.name == dataset
-        assert download_cls.data_dir == data_dir
-        assert download_cls.extract_data == extract_data
-        assert download_cls.verbose == verbose
-        assert download_cls.cache_manager == True  # mocked value
-        assert download_cls.save_data_dir == '/path/to/cache/downloads/'
-        assert download_cls.save_cache_dir == '/path/to/cache/'
+        assert download_cls.name == test_data["dataset"]
+        assert download_cls.data_dir == test_data["data_dir"]
+        assert download_cls.extract_data == test_data["extract_data"]
+        assert download_cls.verbose == test_data["verbose"]
 
-    def test_init__raises_error_missing_inputs(self, mocker):
+    def test_init__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
-            download_cls = DownloadAPI()
+            DownloadAPI()
+
+    def test_init__raises_error_too_many_input_args(self, mocker, test_data):
+        with pytest.raises(TypeError):
+            DownloadAPI(test_data['dataset'], test_data['data_dir'], test_data['extract_data'], test_data['verbose'], 'extra_input')
 
     def test_init__raises_error_missing_one_input(self, mocker):
-        dataset, data_dir, extract_data, verbose = test_db_data()
-
         with pytest.raises(TypeError):
-            download_cls = DownloadAPI(dataset, data_dir, extract_data)
+            DownloadAPI('some_dataset', '/some/dir/path', False)
 
-    def test_get_download_data_dir_return_data_dir(self, mocker):
-        mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
-        mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
-        dataset, data_dir, extract_data, verbose = test_db_data()
+    def test_run(self, mocker, download_api_cls):
+        mock_exists = mocker.patch.object(DownloadAPI, 'exists_dataset_in_cache', return_value=False)
+        mock_download = mocker.patch.object(DownloadAPI, 'download_dataset')
+        mock_update = mocker.patch.object(DownloadAPI, 'update_cache')
 
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        result = download_cls.get_download_data_dir()
+        download_api_cls.run()
 
-        assert result == data_dir
-
-    @pytest.mark.parametrize("data_dir", ['', None])
-    def test_get_download_data_dir_generate_data_dir(self, mocker, data_dir):
-        mocker.patch.object(DownloadAPI, "get_cache_manager", return_value=True)
-        mocker.patch.object(DownloadAPI, "get_download_cache_dir", return_value='/path/to/cache/')
-        mocker.patch.object(DownloadAPI, "get_download_data_dir_from_cache", return_value='/some/path/')
-        dataset, _, extract_data, verbose = test_db_data()
-
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        result = download_cls.get_download_data_dir()
-
-        assert result == '/some/path/'
-
-    def test_download_dataset_run_constructor(self, mocker, mocks_init_class):
-        mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
-        dataset, data_dir, extract_data, verbose = test_db_data()
-
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        download_cls.download_dataset()
-
-        assert_mock_init_class(mocks_init_class)
-        assert mock_constructor.called
-
-    def test_update_cache_dataset_exists(self, mocker, mocks_init_class):
-        mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=True)
-        mock_update = mocker.patch.object(DownloadAPI, "update_dataset_info_in_cache")
-        dataset, data_dir, extract_data, verbose = test_db_data()
-
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        download_cls.update_cache()
-
-        assert_mock_init_class(mocks_init_class)
-        assert mock_exists.return_value == True
+        assert mock_exists.called
+        assert mock_download.called
         assert mock_update.called
 
-    def test_update_cache_dataset_not_exists(self, mocker, mocks_init_class):
+    def test_run_skip_downloading(self, mocker, download_api_cls):
+        mock_exists = mocker.patch.object(DownloadAPI, 'exists_dataset_in_cache', return_value=True)
+        mock_download = mocker.patch.object(DownloadAPI, 'download_dataset')
+        mock_update = mocker.patch.object(DownloadAPI, 'update_cache')
+
+        download_api_cls.run()
+
+        assert mock_exists.called
+        assert not mock_download.called
+        assert not mock_update.called
+
+    def test_get_dataset_constructor(self, mocker, download_api_cls):
+        mock_metadata_obj = mocker.patch.object(DownloadAPI, "get_dataset_metadata_obj", return_value=mocker.MagicMock())
+
+        download_api_cls.get_dataset_constructor()
+
+        assert mock_metadata_obj.called
+
+    def test_get_download_data_dir__data_dir_valid(self, mocker, download_api_cls):
+        mock_get_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir_from_cache", return_value='/some/cache/dir')
+
+        download_api_cls.data_dir = '/valid/dir/path'
+        result = download_api_cls.get_download_data_dir()
+
+        assert not mock_get_dir.called
+        assert result == '/valid/dir/path'
+
+    def test_get_download_data_dir__data_dir_empty(self, mocker, download_api_cls):
+        mock_get_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir_from_cache", return_value='/some/cache/dir')
+
+        download_api_cls.data_dir = ''
+        result = download_api_cls.get_download_data_dir()
+
+        assert mock_get_dir.called
+        assert result == '/some/cache/dir'
+
+    def get_download_data_dir_from_cache(self, mocker, download_api_cls):
+        mock_get_dir = mocker.patch.object(DownloadAPI, "get_cache_download_dir_path", return_value='/download/dir/path')
+        mock_create_dir = mocker.patch.object(DownloadAPI, "create_dir")
+
+        result = download_api_cls.get_download_data_dir_from_cache()
+
+        assert mock_get_dir.called
+        assert mock_create_dir.called
+        assert result == os.path.join('/download/dir/path', download_api_cls.name)
+
+    def test_get_download_cache_dir(self, mocker, download_api_cls):
+        mock_get_dir = mocker.patch.object(DownloadAPI, "get_cache_dir", return_value='/cache/dir/path')
+        mock_create_dir = mocker.patch.object(DownloadAPI, "create_dir")
+
+        result = download_api_cls.get_download_cache_dir()
+
+        assert mock_get_dir.called
+        assert mock_create_dir.called
+        assert result == os.path.join('/cache/dir/path', download_api_cls.name)
+
+    def test_download_dataset(self, mocker, download_api_cls):
+        mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
+        mock_data_dir = mocker.patch.object(DownloadAPI, 'get_download_data_dir', return_value='/some/path/data/dir')
+        mock_cache_dir = mocker.patch.object(DownloadAPI, 'get_download_cache_dir', return_value='/some/path/cache/dir')
+
+        download_api_cls.download_dataset()
+
+        assert mock_constructor.called
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
+
+    def test_update_cache__dataset_exists_in_cache(self, mocker, download_api_cls):
+        mock_data_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/some/path/data/dir')
+        mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=True)
+        mock_update = mocker.patch.object(DownloadAPI, "update_dataset_info_in_cache")
+        mock_add = mocker.patch.object(DownloadAPI, "add_dataset_info_to_cache")
+
+        download_api_cls.update_cache()
+
+        assert mock_data_dir.called
+        assert mock_exists.called
+        assert mock_update.called
+        assert not mock_add.called
+
+    def test_update_cache__dataset_does_not_exist_in_cache(self, mocker, download_api_cls):
+        mock_data_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/some/path/data/dir')
+        mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=False)
+        mock_update = mocker.patch.object(DownloadAPI, "update_dataset_info_in_cache")
+        mock_add = mocker.patch.object(DownloadAPI, "add_dataset_info_to_cache")
+
+        download_api_cls.update_cache()
+
+        assert mock_data_dir.called
+        assert mock_exists.called
+        assert not mock_update.called
+        assert mock_add.called
+
+    def test_update_cache_dataset_not_exists(self, mocker, mocks_init_class, download_api_cls):
         mock_exists = mocker.patch.object(DownloadAPI, "exists_dataset_in_cache", return_value=False)
         mock_add = mocker.patch.object(DownloadAPI, "add_dataset_info_to_cache")
-        dataset, data_dir, extract_data, verbose = test_db_data()
 
-        download_cls = DownloadAPI(dataset, data_dir, extract_data, verbose)
-        download_cls.update_cache()
+        download_api_cls.update_cache()
 
-        assert_mock_init_class(mocks_init_class)
-        assert mock_exists.return_value == False
+        assert mock_exists.called
         assert mock_add.called

--- a/dbcollection/tests/core/api/test_download.py
+++ b/dbcollection/tests/core/api/test_download.py
@@ -185,15 +185,22 @@ class TestClassDownloadAPI:
         assert result == os.path.join('/cache/dir/path', download_api_cls.name)
 
     def test_download_dataset(self, mocker, download_api_cls):
-        mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
         mock_data_dir = mocker.patch.object(DownloadAPI, 'get_download_data_dir', return_value='/some/path/data/dir')
         mock_cache_dir = mocker.patch.object(DownloadAPI, 'get_download_cache_dir', return_value='/some/path/cache/dir')
+        mock_download = mocker.patch.object(DownloadAPI, "download_dataset_files")
 
         download_api_cls.download_dataset()
 
-        assert mock_constructor.called
         assert mock_data_dir.called
         assert mock_cache_dir.called
+        assert mock_download.called
+
+    def test_download_dataset_files(self, mocker, download_api_cls):
+        mock_constructor = mocker.patch.object(DownloadAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
+
+        download_api_cls.download_dataset_files('/some/path/data', '/some/path/cache')
+
+        assert mock_constructor.called
 
     def test_update_cache__dataset_exists_in_cache(self, mocker, download_api_cls):
         mock_data_dir = mocker.patch.object(DownloadAPI, "get_download_data_dir", return_value='/some/path/data/dir')

--- a/dbcollection/tests/core/api/test_info.py
+++ b/dbcollection/tests/core/api/test_info.py
@@ -36,7 +36,7 @@ def test_data():
 class TestCallInfo:
     """Unit tests for the core api info method."""
 
-    def test_call(self, mocker, mocks_init_class, test_data):
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(InfoAPI, "run")
 
         info(test_data['by_dataset'],
@@ -50,7 +50,7 @@ class TestCallInfo:
 
         assert mock_run.called
 
-    def test_call_with_named_args(self, mocker, mocks_init_class, test_data):
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(InfoAPI, "run")
 
         info(by_dataset=test_data['by_dataset'],
@@ -64,14 +64,14 @@ class TestCallInfo:
 
         assert mock_run.called
 
-    def test_call_without_optional_args(self, mocker):
+    def test_call_without_optional_input_args(self, mocker):
         mock_run = mocker.patch.object(InfoAPI, "run")
 
         info()
 
         assert mock_run.called
 
-    def test_call__raises_error_too_many_input_args(self, mocker, test_data):
+    def test_call__raises_error_too_many_args(self, mocker, test_data):
         with pytest.raises(TypeError):
             info(test_data['by_dataset'],
                  test_data['by_task'],

--- a/dbcollection/tests/core/api/test_load.py
+++ b/dbcollection/tests/core/api/test_load.py
@@ -9,19 +9,19 @@ from dbcollection.core.api.load import load, LoadAPI
 
 
 @pytest.fixture()
-def mocks_api(mocker):
-    mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=True)
+def mocks_init_class(mocker):
+    mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value='taskA')
     mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
-    mock_run = mocker.patch.object(LoadAPI, "run", return_value=True)
-    return [mock_parse, mock_cache, mock_run]
+    return [mock_parse, mock_cache]
 
 
-def assert_mock_api(mocks):
+def assert_mock_init_class(mocks):
     for mock in mocks:
         assert mock.called
 
 
-def generate_inputs_for_load():
+@pytest.fixture()
+def test_data():
     return {
         "dataset": 'mnist',
         "task": 'some_task',
@@ -33,32 +33,38 @@ def generate_inputs_for_load():
 class TestCallLoad:
     """Unit tests for the core api load method."""
 
-    def test_call_with_dataset_name_only(self, mocker, mocks_api):
-        inputs = generate_inputs_for_load()
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value={})
 
-        data_loader = load(inputs["dataset"])
+        data_loader = load(test_data["dataset"],
+                           test_data["task"],
+                           test_data["data_dir"],
+                           test_data["verbose"])
 
-        assert_mock_api(mocks_api)
-        assert data_loader == True
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == {}
 
-    def test_call_with_all_inputs(self, mocker, mocks_api):
-        inputs = generate_inputs_for_load()
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value={})
 
-        data_loader = load(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
+        data_loader = load(name=test_data["dataset"],
+                           task=test_data["task"],
+                           data_dir=test_data["data_dir"],
+                           verbose=test_data["verbose"])
 
-        assert_mock_api(mocks_api)
-        assert data_loader == True
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == {}
 
-    def test_call_with_all_inputs_named_args(self, mocker, mocks_api):
-        inputs = generate_inputs_for_load()
+    def test_call_without_optional_input_args(self, mocker, mocks_init_class):
+        mock_run = mocker.patch.object(LoadAPI, "run", return_value={})
 
-        data_loader = load(name=inputs["dataset"],
-                           task=inputs["task"],
-                           data_dir=inputs["data_dir"],
-                           verbose=inputs["verbose"])
+        data_loader = load('some_dataset')
 
-        assert_mock_api(mocks_api)
-        assert data_loader == True
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+        assert data_loader == {}
 
     def test_call__raises_error_no_inputs(self, mocker):
         with pytest.raises(TypeError):
@@ -68,183 +74,114 @@ class TestCallLoad:
         with pytest.raises(TypeError):
             load("some_dataset", "some_task", "some_dir", True, "extra_field")
 
-@pytest.fixture
-def mocks_init_class(mocker):
-    inputs = generate_inputs_for_load()
-    mock_parse = mocker.patch.object(LoadAPI, "parse_task_name", return_value=inputs["task"])
-    mock_cache = mocker.patch.object(LoadAPI, "get_cache_manager")
-    return [mock_parse, mock_cache]
 
-
-def assert_mock_init_class(mocks):
-    for mock in mocks:
-        assert mock.called
-
-
-def mock_run_method(mocker, data_exists, task_exists):
-    assert data_exists is not None
-    assert task_exists is not None
-
-    mock_data_exists = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=data_exists)
-    mock_download = mocker.patch.object(LoadAPI, "download_dataset_data")
-    mock_task_exists = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=task_exists)
-    mock_process = mocker.patch.object(LoadAPI, "process_dataset_task_metadata")
-    mock_data_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value=["data_loader_dummy_data"])
-
-    return {
-        "data_exists": mock_data_exists,
-        "download": mock_download,
-        "task_exists": mock_task_exists,
-        "process": mock_process,
-        "data_loader": mock_data_loader
-    }
-
-
-def eval_run_method_calls(mocks, data_exists, task_exists):
-    assert mocks
-    assert data_exists is not None
-    assert task_exists is not None
-
-    assert mocks["data_exists"].called
-    assert mocks["task_exists"].called
-    assert mocks["data_loader"].called
-
-    if not data_exists:
-        assert mocks["download"].called
-    else:
-        assert not mocks["download"].called
-
-    if not task_exists:
-        assert mocks["process"].called
-    else:
-        assert not mocks["process"].called
+@pytest.fixture()
+def load_api_cls(mocker, mocks_init_class, test_data):
+    return LoadAPI(
+        name=test_data["dataset"],
+        task=test_data["task"],
+        data_dir=test_data["data_dir"],
+        verbose=test_data["verbose"]
+    )
 
 
 class TestClassLoadAPI:
     """Unit tests for the LoadAPI class."""
 
-    def test_init_with_all_inputs(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-
-        assert_mock_init_class(mocks_init_class)
-        assert load_api.name == inputs["dataset"]
-        assert load_api.task == inputs["task"]
-        assert load_api.data_dir == inputs["data_dir"]
-        assert load_api.verbose == inputs["verbose"]
-
-    def test_init_with_all_inputs_named_args(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-
-        load_api = LoadAPI(name=inputs["dataset"],
-                           task=inputs["task"],
-                           data_dir=inputs["data_dir"],
-                           verbose=inputs["verbose"])
+    def test_init_with_all_input_args(self, mocker, mocks_init_class, test_data):
+        load_api = LoadAPI(name=test_data["dataset"],
+                           task=test_data["task"],
+                           data_dir=test_data["data_dir"],
+                           verbose=test_data["verbose"])
 
         assert_mock_init_class(mocks_init_class)
-        assert load_api.name == inputs["dataset"]
-        assert load_api.task == inputs["task"]
-        assert load_api.data_dir == inputs["data_dir"]
-        assert load_api.verbose == inputs["verbose"]
+        assert load_api.name == test_data["dataset"]
+        assert load_api.task == 'taskA'
+        assert load_api.data_dir == test_data["data_dir"]
+        assert load_api.verbose == test_data["verbose"]
 
-    def test_init__raises_error_missing_inputs(self, mocker):
+    def test_init__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
             LoadAPI()
 
-    @pytest.mark.parametrize("dataset, task, data_dir, verbose", [
-        ('mnist', 'classification', 'some_dir', None),
-        ('mnist', 'some_task', None, True),
-        ('some_dataset', None, 'some_dir', False),
-        (None, 'some_task', 'some_dir', False),
-        (None, None, None, None)
-    ])
-    def test_init__raises_error_missing_some_inputs(self, mocker, dataset, task, data_dir, verbose):
-        with pytest.raises(AssertionError):
-            LoadAPI(dataset, task, data_dir, verbose)
-
-    def test_init__raises_error_extra_inputs(self, mocker):
+    def test_init__raises_error_too_many_input_args(self, mocker, mocks_init_class, test_data):
         with pytest.raises(TypeError):
-            LoadAPI("some_dataset", "some_task", "some_dir", True, "extra_field")
+            LoadAPI(test_data['dataset'], test_data['task'], test_data['data_dir'], test_data['verbose'], 'extra_input')
 
-    def test_run_dataset_data_files_and_task_exist_in_cache(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-        mocks = mock_run_method(mocker, data_exists=True, task_exists=True)
+    def test_init__raises_error_missing_one_input_arg(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            LoadAPI(test_data['dataset'], test_data['task'], test_data['data_dir'])
 
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        data_loader = load_api.run()
+    @pytest.mark.parametrize("test_exists_dataset, test_exists_metadata", [
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True)
+    ])
+    def test_run(self, mocker, load_api_cls, test_exists_dataset, test_exists_metadata):
+        mock_exists_dataset = mocker.patch.object(LoadAPI, "dataset_data_exists_in_cache", return_value=test_exists_dataset)
+        mock_download = mocker.patch.object(LoadAPI, "download_dataset_data")
+        mock_exists_metadata = mocker.patch.object(LoadAPI, "dataset_task_metadata_exists_in_cache", return_value=test_exists_metadata)
+        mock_process = mocker.patch.object(LoadAPI, "process_dataset_task_metadata")
+        mock_get_loader = mocker.patch.object(LoadAPI, "get_data_loader", return_value={})
 
-        assert_mock_init_class(mocks_init_class)
-        eval_run_method_calls(mocks, data_exists=True, task_exists=True)
+        data_loader = load_api_cls.run()
 
-    def test_run_dataset_data_files_exist_task_missing_in_cache(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-        mocks = mock_run_method(mocker, data_exists=True, task_exists=False)
+        assert mock_exists_dataset.called
+        assert mock_exists_metadata.called
+        if test_exists_dataset:
+            assert not mock_download.called
+        else:
+            assert mock_download
+        if test_exists_metadata:
+            assert not mock_process.called
+        else:
+            assert mock_process
+        assert mock_get_loader.called
+        assert data_loader == {}
 
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        data_loader = load_api.run()
-
-        assert_mock_init_class(mocks_init_class)
-        eval_run_method_calls(mocks, data_exists=True, task_exists=False)
-
-    def test_run_dataset_data_files_missing_task_exists_in_cache(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-        mocks = mock_run_method(mocker, data_exists=False, task_exists=True)
-
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        data_loader = load_api.run()
-
-        assert_mock_init_class(mocks_init_class)
-        eval_run_method_calls(mocks, data_exists=False, task_exists=True)
-
-    def test_run_dataset_files_and_task_missing_in_cache(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-        mocks = mock_run_method(mocker, data_exists=False, task_exists=False)
-
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        data_loader = load_api.run()
-
-        assert_mock_init_class(mocks_init_class)
-        eval_run_method_calls(mocks, data_exists=False, task_exists=False)
-
-    def test_download_dataset_data(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
+    def test_download_dataset_data(self, mocker, load_api_cls):
         mock_download = mocker.patch.object(LoadAPI, "download_dataset")
         mock_reload = mocker.patch.object(LoadAPI, "reload_cache")
 
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        load_api.download_dataset_data()
+        load_api_cls.download_dataset_data()
 
-        assert_mock_init_class(mocks_init_class)
         assert mock_download.called
         assert mock_reload.called
 
-    def test_process_dataset_task_metadata(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
+    def test_process_dataset_task_metadata(self, mocker, load_api_cls):
         mock_process = mocker.patch.object(LoadAPI, "process_dataset")
         mock_reload = mocker.patch.object(LoadAPI, "reload_cache")
 
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        load_api.process_dataset_task_metadata()
+        load_api_cls.process_dataset_task_metadata()
 
-        assert_mock_init_class(mocks_init_class)
         assert mock_process.called
         assert mock_reload.called
 
-    def test_get_data_loader(self, mocker, mocks_init_class):
-        inputs = generate_inputs_for_load()
-        mock_data_dir = mocker.patch.object(LoadAPI, "get_data_dir_path_from_cache",
-                                            return_value="/some/path/data/")
-        mock_hdf5_filepath = mocker.patch.object(LoadAPI, "get_hdf5_file_path_from_cache",
-                                            return_value="/some/path/to/file")
-        mock_loader = mocker.patch.object(LoadAPI, "get_loader_obj",
-                                            return_value=["data_loader_dummy"])
+    def test_get_data_loader(self, mocker, load_api_cls):
+        mock_data_dir = mocker.patch.object(LoadAPI, "get_data_dir_path_from_cache", return_value="/some/path/data/")
+        mock_hdf5_filepath = mocker.patch.object(LoadAPI, "get_hdf5_file_path_from_cache", return_value="/some/path/to/file")
+        mock_loader = mocker.patch.object(LoadAPI, "get_loader_obj", return_value=["data_loader_dummy"])
 
-        load_api = LoadAPI(inputs["dataset"], inputs["task"], inputs["data_dir"], inputs["verbose"])
-        data_loader = load_api.get_data_loader()
+        data_loader = load_api_cls.get_data_loader()
 
-        assert_mock_init_class(mocks_init_class)
         assert mock_data_dir.called
         assert mock_hdf5_filepath.called
         assert mock_loader.called
         assert data_loader == ["data_loader_dummy"]
+
+    def test_get_data_dir_path_from_cache(self, mocker, load_api_cls):
+        mock_get_metadata = mocker.patch.object(LoadAPI, "get_dataset_metadata", return_value={'data_dir': '/some/path/data'})
+
+        result = load_api_cls.get_data_dir_path_from_cache()
+
+        assert mock_get_metadata.called
+        assert result == '/some/path/data'
+
+    def test_get_hdf5_file_path_from_cache(self, mocker, load_api_cls):
+        mock_get_metadata = mocker.patch.object(LoadAPI, "get_task_metadata", return_value={'filename': '/some/path/cache/task.h5'})
+
+        result = load_api_cls.get_hdf5_file_path_from_cache()
+
+        assert mock_get_metadata.called
+        assert result == '/some/path/cache/task.h5'

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -130,19 +130,20 @@ class TestClassProcessAPI:
         assert result == os.path.join('/path/dir/cache', process_api_cls.name)
 
     def test_process_dataset(self, mocker, process_api_cls):
-        mock_constructor = mocker.patch.object(ProcessAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
         mock_data_dir = mocker.patch.object(ProcessAPI, 'get_dataset_data_dir_path', return_value='/some/path/data/dir')
         mock_cache_dir = mocker.patch.object(ProcessAPI, 'get_dataset_cache_dir_path', return_value='/some/path/cache/dir')
         mock_parse_task = mocker.patch.object(ProcessAPI, "parse_task_name", return_value='correct_task')
         mock_check_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
+        mock_process_metadata = mocker.patch.object(ProcessAPI, "process_dataset_metadata", return_value={})
 
-        process_api_cls.process_dataset()
+        result = process_api_cls.process_dataset()
 
-        assert mock_constructor.called
         assert mock_data_dir.called
         assert mock_cache_dir.called
         assert mock_parse_task.called
         assert mock_check_exists.called
+        assert mock_process_metadata.called
+        assert result == {}
 
     def test_get_dataset_data_dir_path(self, mocker, process_api_cls):
         mock_get_metadata = mocker.patch.object(ProcessAPI, "get_dataset_metadata_from_cache", return_value={'data_dir': '/some/dir/path'})
@@ -186,3 +187,10 @@ class TestClassProcessAPI:
             process_api_cls.check_if_task_exists_in_database('invalid_task')
 
         assert mock_exists.called
+
+    def test_process_dataset_metadata(self, mocker, process_api_cls):
+        mock_constructor = mocker.patch.object(ProcessAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
+
+        result = process_api_cls.process_dataset_metadata('/some/path/data', '/some/path/cache', 'taskA')
+
+        assert mock_constructor.called

--- a/dbcollection/tests/core/api/test_process.py
+++ b/dbcollection/tests/core/api/test_process.py
@@ -3,6 +3,7 @@ Test dbcollection core API: process.
 """
 
 
+import os
 import pytest
 
 from dbcollection.core.api.process import process, ProcessAPI
@@ -11,10 +12,7 @@ from dbcollection.core.api.process import process, ProcessAPI
 @pytest.fixture()
 def mocks_init_class(mocker):
     mock_cache = mocker.patch.object(ProcessAPI, "get_cache_manager", return_value=True)
-    mock_data_dir = mocker.patch.object(ProcessAPI, "get_dataset_data_dir_path", return_value='/some/path/cache/db')
-    mock_cache_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/some/path/cache')
-    mock_exists = mocker.patch.object(ProcessAPI, 'check_if_task_exists_in_database')
-    return [mock_cache, mock_data_dir, mock_cache_dir, mock_exists]
+    return [mock_cache]
 
 
 def assert_mock_init_class(mocks):
@@ -22,25 +20,40 @@ def assert_mock_init_class(mocks):
         assert mock.called
 
 
+@pytest.fixture()
+def test_data():
+    return {
+        "dataset": 'some_dataset',
+        "task": 'some_task',
+        "verbose": False
+    }
+
+
 class TestCallProcess:
     """Unit tests for the core api process method."""
 
-    def test_call_with_dataset_name(self, mocker, mocks_init_class):
+    def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(ProcessAPI, "run")
-        dataset = 'mnist'
 
-        process(dataset)
+        process(test_data["dataset"], test_data["task"], test_data["verbose"])
 
         assert_mock_init_class(mocks_init_class)
         assert mock_run.called
 
-    def test_call_with_all_inputs(self, mocker, mocks_init_class):
+    def test_call_with_named_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(ProcessAPI, "run")
-        dataset = 'mnist'
-        task = ''
-        verbose = True
 
-        process(dataset, task=task, verbose=verbose)
+        process(name=test_data["dataset"],
+                task=test_data["task"],
+                verbose=test_data["verbose"])
+
+        assert_mock_init_class(mocks_init_class)
+        assert mock_run.called
+
+    def test_call_without_optional_input_args(self, mocker,  mocks_init_class, test_data):
+        mock_run = mocker.patch.object(ProcessAPI, "run")
+
+        process('some_dataset')
 
         assert_mock_init_class(mocks_init_class)
         assert mock_run.called
@@ -49,80 +62,127 @@ class TestCallProcess:
         with pytest.raises(TypeError):
             process()
 
-    def test_call__raises_error_invalid_dataset_name(self, mocker):
-        with pytest.raises(KeyError):
-            process('invalid_dataset_name')
+    def test_call__raises_error_too_many_args(self, mocker):
+        with pytest.raises(TypeError):
+            process('some_dataset', 'some_task', True, 'extra_field')
+
+
+@pytest.fixture()
+def process_api_cls(mocker, mocks_init_class, test_data):
+    return ProcessAPI(
+        name=test_data['dataset'],
+        task=test_data['task'],
+        verbose=test_data['verbose']
+    )
 
 
 class TestClassProcessAPI:
     """Unit tests for the ProcessAPI class."""
 
-    def test_init_with_all_inputs(self, mocker, mocks_init_class):
-        dataset = 'mnist'
-        task = 'default'
-        verbose = True
-
-        process_api = ProcessAPI(dataset, task, verbose)
+    def test_init_with_all_input_args(self, mocker, mocks_init_class, test_data):
+        process_api = ProcessAPI(name=test_data['dataset'],
+                                 task=test_data['task'],
+                                 verbose=test_data['verbose'])
 
         assert_mock_init_class(mocks_init_class)
-        assert process_api.name == dataset
-        assert process_api.task == 'classification'  # default task name for mnist
-        assert process_api.verbose == verbose
+        assert process_api.name == test_data["dataset"]
+        assert process_api.task == test_data["task"]
+        assert process_api.verbose == test_data["verbose"]
 
-    def test_init__raises_error_missing_inputs(self, mocker):
+    def test_init__raises_error_no_input_args(self, mocker, mocks_init_class, test_data):
         with pytest.raises(TypeError):
             ProcessAPI()
 
-    @pytest.mark.parametrize("dataset, task, verbose", [
-        ('mnist', 'classification', None),
-        ('mnist', None, True),
-        (None, '', False),
-        ('', 'default', False),
-        (None, None, None)
-    ])
-    def test_init__raises_error_missing_some_inputs(self, mocker, dataset, task, verbose):
-        with pytest.raises(AssertionError):
-            ProcessAPI(dataset, task, verbose)
+    def test_init__raises_error_too_many_input_args(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            ProcessAPI(test_data['dataset'], test_data['task'], test_data['verbose'], 'extra_input')
 
-    @pytest.mark.parametrize("test_task", ['classification', 'some_task', 'another_task'])
-    def test_parse_task_name(self, mocker, mocks_init_class, test_task):
-        process_api = ProcessAPI('mnist', test_task, True)
+    def test_init__raises_error_missing_one_input_arg(self, mocker, mocks_init_class, test_data):
+        with pytest.raises(TypeError):
+            ProcessAPI(test_data['dataset'], test_data['task'])
 
-        assert_mock_init_class(mocks_init_class)
-        assert process_api.parse_task_name(test_task) == test_task
-
-    @pytest.mark.parametrize("test_task", ['', 'default'])
-    def test_parse_task_name_to_default(self, mocker, mocks_init_class, test_task):
-        process_api = ProcessAPI('mnist', '', True)
-
-        assert_mock_init_class(mocks_init_class)
-        assert process_api.parse_task_name(test_task) == "classification"
-
-    def test_run(self, mocker, mocks_init_class):
-        mock_create = mocker.patch.object(ProcessAPI, "create_dir")
-        mock_process = mocker.patch.object(ProcessAPI, "process_dataset", return_value="some_info")
+    def test_run(self, mocker, process_api_cls):
+        mock_set_dirs = mocker.patch.object(ProcessAPI, "set_dirs_processed_metadata")
+        mock_process = mocker.patch.object(ProcessAPI, "process_dataset", return_value={'dummy': 'data'})
         mock_update = mocker.patch.object(ProcessAPI, "update_cache")
-        dataset = 'mnist'
-        task = 'some_task'
-        verbose = True
 
-        process_api = ProcessAPI(dataset, task, verbose)
-        process_api.run()
+        process_api_cls.run()
 
-        assert_mock_init_class(mocks_init_class)
-        assert mock_create.called
-        assert mock_process.return_value == "some_info"
+        assert mock_set_dirs.called
+        assert mock_process.called
         assert mock_update.called
 
-    def test_process_dataset(self, mocker, mocks_init_class):
+    def test_set_dirs_processed_metadata(self, mocker, process_api_cls):
+        mock_get_dir = mocker.patch.object(ProcessAPI, "get_dataset_cache_dir_path", return_value='/path/dir/cache')
+        mock_create_dir = mocker.patch.object(ProcessAPI, "create_dir")
+
+        process_api_cls.set_dirs_processed_metadata()
+
+        assert mock_get_dir.called
+        assert mock_create_dir.called
+
+    def test_get_dataset_cache_dir_path(self, mocker, process_api_cls):
+        mock_get_dir = mocker.patch.object(ProcessAPI, "get_cache_dir_path_from_cache", return_value='/path/dir/cache')
+
+        result = process_api_cls.get_dataset_cache_dir_path()
+
+        assert mock_get_dir.called
+        assert result == os.path.join('/path/dir/cache', process_api_cls.name)
+
+    def test_process_dataset(self, mocker, process_api_cls):
         mock_constructor = mocker.patch.object(ProcessAPI, "get_dataset_constructor", return_value=mocker.MagicMock())
-        dataset = 'mnist'
-        task = 'some_task'
-        verbose = True
+        mock_data_dir = mocker.patch.object(ProcessAPI, 'get_dataset_data_dir_path', return_value='/some/path/data/dir')
+        mock_cache_dir = mocker.patch.object(ProcessAPI, 'get_dataset_cache_dir_path', return_value='/some/path/cache/dir')
+        mock_parse_task = mocker.patch.object(ProcessAPI, "parse_task_name", return_value='correct_task')
+        mock_check_exists = mocker.patch.object(ProcessAPI, "check_if_task_exists_in_database")
 
-        process_api = ProcessAPI(dataset, task, verbose)
-        task_info = process_api.process_dataset()
+        process_api_cls.process_dataset()
 
-        assert_mock_init_class(mocks_init_class)
         assert mock_constructor.called
-        assert task_info is not None
+        assert mock_data_dir.called
+        assert mock_cache_dir.called
+        assert mock_parse_task.called
+        assert mock_check_exists.called
+
+    def test_get_dataset_data_dir_path(self, mocker, process_api_cls):
+        mock_get_metadata = mocker.patch.object(ProcessAPI, "get_dataset_metadata_from_cache", return_value={'data_dir': '/some/dir/path'})
+
+        result = process_api_cls.get_dataset_data_dir_path()
+
+        assert mock_get_metadata.called
+        assert result == '/some/dir/path'
+
+    @pytest.mark.parametrize("task", ['', 'default', 'classification', 'recognition', 'another_task'])
+    def test_parse_task_name(self, mocker, process_api_cls, task):
+        mock_get_default = mocker.patch.object(ProcessAPI, "get_default_task", return_value='default_task')
+
+        result = process_api_cls.parse_task_name(task)
+
+        if not (task == '' or task == 'default'):
+            assert not mock_get_default.called
+            assert result == task
+        else:
+            assert mock_get_default.called
+            assert result == 'default_task'
+
+    def test_get_default_task(self, mocker, process_api_cls):
+        mock_get_metadata = mocker.patch.object(ProcessAPI, "get_dataset_metadata_obj", return_value=mocker.MagicMock())
+
+        process_api_cls.get_default_task()
+
+        assert mock_get_metadata.called
+
+    def test_check_if_task_exists_in_database__dataset_exists(self, mocker, process_api_cls):
+        mock_exists = mocker.patch.object(ProcessAPI, "exists_task", return_value=True)
+
+        process_api_cls.check_if_task_exists_in_database('some_task')
+
+        assert mock_exists.called
+
+    def test_check_if_task_exists_in_database__dataset_does_not_exist(self, mocker, process_api_cls):
+        mock_exists = mocker.patch.object(ProcessAPI, "exists_task", return_value=False)
+
+        with pytest.raises(KeyError):
+            process_api_cls.check_if_task_exists_in_database('invalid_task')
+
+        assert mock_exists.called

--- a/dbcollection/tests/core/api/test_remove.py
+++ b/dbcollection/tests/core/api/test_remove.py
@@ -35,7 +35,10 @@ class TestCallRemove:
     def test_call_with_all_input_args(self, mocker, mocks_init_class, test_data):
         mock_run = mocker.patch.object(RemoveAPI, 'run')
 
-        remove(test_data['dataset'], test_data['task'], test_data['delete_data'], test_data['verbose'])
+        remove(test_data['dataset'],
+               test_data['task'],
+               test_data['delete_data'],
+               test_data['verbose'])
 
         assert_mock_call(mocks_init_class)
         assert mock_run.called
@@ -51,10 +54,10 @@ class TestCallRemove:
         assert_mock_call(mocks_init_class)
         assert mock_run.called
 
-    def test_call_without_optional_input_args(self, mocker, mocks_init_class, test_data):
+    def test_call_without_optional_input_args(self, mocker, mocks_init_class):
         mock_run = mocker.patch.object(RemoveAPI, 'run')
 
-        remove(test_data['dataset'])
+        remove('datasetX')
 
         assert_mock_call(mocks_init_class)
         assert mock_run.called


### PR DESCRIPTION
This PR addresses #119 and refactors/fixes the unit tests such that they all follow the same scheme of testing. This allows to more easily understand how unit tests are set and improves the overall readability of tests for the core api.