### PR TITLE
[Refactor] improve BaseDataset class  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ test-utils:
 	make build
 	pipenv run pytest -v dbcollection/tests/utils
 
+.PHONY: test-datasets
+test-datasets:
+	make build
+	pipenv run pytest -v dbcollection/tests/datasets
+
 .PHONY: lint
 lint:
 	pipenv run tox -e flake8
@@ -77,6 +82,7 @@ lint:
 .PHONY: urls_check
 urls_check:
 	pipenv run tox -e urls_check_health
+
 
 ##########
 # Deploy

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -13,8 +13,10 @@ import h5py
 
 from dbcollection.utils.url import download_extract_all
 
-
 class BaseDataset(object):
+    pass
+
+class BaseDatasetNew(object):
     """Base class for download/processing a dataset.
 
     Parameters

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -238,7 +238,7 @@ class BaseDatasetNew(object):
         if self.verbose:
             print("\nProcessing '{}' task:".format(task_))
         hdf5_filename = self.process_metadata(task_)
-        return {task_: hdf5_filename}
+        return {task_: {"filename": hdf5_filename, "categories": self.keywords}}
 
     def parse_task_name(self, task):
         """Parses the task name to a valid name."""

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -13,6 +13,7 @@ import h5py
 
 from dbcollection.utils.url import download_extract_all
 
+
 class BaseDataset(object):
     """ Base class for download/processing a dataset.
 
@@ -193,9 +194,7 @@ class BaseDatasetNew(object):
     urls = ()  # list of urls to download
     keywords = ()  # List of keywords to classify/categorize datasets in the cache.
     tasks = {}  # dictionary of available tasks to process
-                # Example: tasks = {'classification':Classification}
-    default_task = ''  # Defines the default class!
-                       # Example: default_task='classification'
+    default_task = ''  # Defines the default class
 
     def __init__(self, data_path, cache_path, extract_data=True, verbose=True):
         """Initialize class."""

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -1,0 +1,12 @@
+"""
+Test the base classes for managing datasets and tasks.
+"""
+
+
+import pytest
+
+from dbcollection.datasets import BaseDataset
+
+
+class TestBaseDataset:
+    """Unit tests for the BaseDataset class."""

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -8,5 +8,124 @@ import pytest
 from dbcollection.datasets import BaseDataset
 
 
+@pytest.fixture()
+def test_data():
+    return {
+        "data_path": '/path/to/data',
+        "cache_path": '/path/to/cache',
+        "extract_data": True,
+        "verbose": True
+    }
+
+
+@pytest.fixture()
+def mock_dataset_class(test_data):
+    return BaseDataset(
+        data_path=test_data["data_path"],
+        cache_path=test_data["cache_path"],
+        extract_data=test_data["extract_data"],
+        verbose=test_data["verbose"]
+    )
+
+
 class TestBaseDataset:
     """Unit tests for the BaseDataset class."""
+
+    def test_init_with_all_input_args(self, mocker):
+        data_path = '/path/to/data'
+        cache_path = '/path/to/cache'
+        extract_data=True
+        verbose=True
+
+        db_manager = BaseDataset(data_path=data_path,
+                                 cache_path=cache_path,
+                                 extract_data=extract_data,
+                                 verbose=verbose)
+
+        assert db_manager.data_path == '/path/to/data'
+        assert db_manager.cache_path == '/path/to/cache'
+        assert db_manager.extract_data == True
+        assert db_manager.verbose == True
+        assert db_manager.urls == ()
+        assert db_manager.keywords == ()
+        assert db_manager.tasks == {}
+        assert db_manager.default_task == ''
+
+    def test_init_withouth_optional_input_args(self, mocker):
+        data_path = '/path/to/data'
+        cache_path = '/path/to/cache'
+
+        db_manager = BaseDataset(data_path=data_path,
+                                 cache_path=cache_path)
+
+        assert db_manager.data_path == '/path/to/data'
+        assert db_manager.cache_path == '/path/to/cache'
+        assert db_manager.extract_data == True
+        assert db_manager.verbose == True
+        assert db_manager.urls == ()
+        assert db_manager.keywords == ()
+        assert db_manager.tasks == {}
+        assert db_manager.default_task == ''
+
+    def test_init__raises_error_no_input_args(self, mocker):
+        with pytest.raises(TypeError):
+            BaseDataset()
+
+    def test_init__raises_error_too_many_input_args(self, mocker):
+        with pytest.raises(TypeError):
+            BaseDataset('/path/to/data', '/path/to/cache', False, False, 'extra_field')
+
+    def test_download(self, mocker, mock_dataset_class):
+        mock_download_extract = mocker.patch("dbcollection.datasets.download_extract_all")
+
+        mock_dataset_class.download()
+
+        assert mock_download_extract.called
+
+    def test_process(self, mocker, mock_dataset_class):
+        mock_parse_task = mocker.patch.object(BaseDataset, "parse_task_name", return_value='taskA')
+        mock_process_metadata = mocker.patch.object(BaseDataset, "process_metadata", return_value='/path/to/task/filename.h5')
+
+        result = mock_dataset_class.process('taskA')
+
+        assert mock_parse_task.called
+        assert mock_process_metadata.called
+        assert result == {'taskA': '/path/to/task/filename.h5'}
+
+    def test_parse_task_name_with_valid_task_name(self, mocker, mock_dataset_class):
+        task = 'taskA'
+
+        result = mock_dataset_class.parse_task_name(task)
+
+        assert result == 'taskA'
+
+    def test_parse_task_name_with_empty_task_name(self, mocker, mock_dataset_class):
+        task = ''
+
+        mock_dataset_class.default_task = 'some_task'
+        result = mock_dataset_class.parse_task_name(task)
+
+        assert result == 'some_task'
+
+    def test_parse_task_name_with_default_task_name(self, mocker, mock_dataset_class):
+        task = 'default'
+
+        mock_dataset_class.default_task = 'some_task'
+        result = mock_dataset_class.parse_task_name(task)
+
+        assert result == 'some_task'
+
+    def test_process_metadata(self, mocker, mock_dataset_class):
+        mock_get_constructor = mocker.patch.object(BaseDataset, "get_task_constructor", return_value=mocker.MagicMock())
+
+        mock_dataset_class.process_metadata('some_task')
+
+        assert mock_get_constructor.called
+
+    def test_get_task_constructor(self, mocker, mock_dataset_class):
+        task = 'taskZ'
+
+        mock_dataset_class.tasks = {task: 'some_data'}
+        result = mock_dataset_class.get_task_constructor(task)
+
+        assert result == 'some_data'

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -5,7 +5,7 @@ Test the base classes for managing datasets and tasks.
 
 import pytest
 
-from dbcollection.datasets import BaseDataset
+from dbcollection.datasets import BaseDatasetNew, BaseTask
 
 
 @pytest.fixture()
@@ -20,7 +20,7 @@ def test_data():
 
 @pytest.fixture()
 def mock_dataset_class(test_data):
-    return BaseDataset(
+    return BaseDatasetNew(
         data_path=test_data["data_path"],
         cache_path=test_data["cache_path"],
         extract_data=test_data["extract_data"],
@@ -28,8 +28,8 @@ def mock_dataset_class(test_data):
     )
 
 
-class TestBaseDataset:
-    """Unit tests for the BaseDataset class."""
+class TestBaseDatasetNew:
+    """Unit tests for the BaseDatasetNew class."""
 
     def test_init_with_all_input_args(self, mocker):
         data_path = '/path/to/data'
@@ -37,7 +37,7 @@ class TestBaseDataset:
         extract_data=True
         verbose=True
 
-        db_manager = BaseDataset(data_path=data_path,
+        db_manager = BaseDatasetNew(data_path=data_path,
                                  cache_path=cache_path,
                                  extract_data=extract_data,
                                  verbose=verbose)
@@ -55,7 +55,7 @@ class TestBaseDataset:
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
 
-        db_manager = BaseDataset(data_path=data_path,
+        db_manager = BaseDatasetNew(data_path=data_path,
                                  cache_path=cache_path)
 
         assert db_manager.data_path == '/path/to/data'
@@ -69,11 +69,11 @@ class TestBaseDataset:
 
     def test_init__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
-            BaseDataset()
+            BaseDatasetNew()
 
     def test_init__raises_error_too_many_input_args(self, mocker):
         with pytest.raises(TypeError):
-            BaseDataset('/path/to/data', '/path/to/cache', False, False, 'extra_field')
+            BaseDatasetNew('/path/to/data', '/path/to/cache', False, False, 'extra_field')
 
     def test_download(self, mocker, mock_dataset_class):
         mock_download_extract = mocker.patch("dbcollection.datasets.download_extract_all")
@@ -83,8 +83,8 @@ class TestBaseDataset:
         assert mock_download_extract.called
 
     def test_process(self, mocker, mock_dataset_class):
-        mock_parse_task = mocker.patch.object(BaseDataset, "parse_task_name", return_value='taskA')
-        mock_process_metadata = mocker.patch.object(BaseDataset, "process_metadata", return_value='/path/to/task/filename.h5')
+        mock_parse_task = mocker.patch.object(BaseDatasetNew, "parse_task_name", return_value='taskA')
+        mock_process_metadata = mocker.patch.object(BaseDatasetNew, "process_metadata", return_value='/path/to/task/filename.h5')
 
         result = mock_dataset_class.process('taskA')
 
@@ -116,7 +116,7 @@ class TestBaseDataset:
         assert result == 'some_task'
 
     def test_process_metadata(self, mocker, mock_dataset_class):
-        mock_get_constructor = mocker.patch.object(BaseDataset, "get_task_constructor", return_value=mocker.MagicMock())
+        mock_get_constructor = mocker.patch.object(BaseDatasetNew, "get_task_constructor", return_value=mocker.MagicMock())
 
         mock_dataset_class.process_metadata('some_task')
 

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -90,7 +90,7 @@ class TestBaseDatasetNew:
 
         assert mock_parse_task.called
         assert mock_process_metadata.called
-        assert result == {'taskA': '/path/to/task/filename.h5'}
+        assert result == {'taskA': {"filename": '/path/to/task/filename.h5', "categories": ()}}
 
     def test_parse_task_name_with_valid_task_name(self, mocker, mock_dataset_class):
         task = 'taskA'

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -37,10 +37,12 @@ class TestBaseDatasetNew:
         extract_data=True
         verbose=True
 
-        db_manager = BaseDatasetNew(data_path=data_path,
-                                 cache_path=cache_path,
-                                 extract_data=extract_data,
-                                 verbose=verbose)
+        db_manager = BaseDatasetNew(
+            data_path=data_path,
+            cache_path=cache_path,
+            extract_data=extract_data,
+            verbose=verbose
+        )
 
         assert db_manager.data_path == '/path/to/data'
         assert db_manager.cache_path == '/path/to/cache'
@@ -55,8 +57,10 @@ class TestBaseDatasetNew:
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
 
-        db_manager = BaseDatasetNew(data_path=data_path,
-                                 cache_path=cache_path)
+        db_manager = BaseDatasetNew(
+            data_path=data_path,
+            cache_path=cache_path
+        )
 
         assert db_manager.data_path == '/path/to/data'
         assert db_manager.cache_path == '/path/to/cache'
@@ -80,7 +84,12 @@ class TestBaseDatasetNew:
 
         mock_dataset_class.download()
 
-        assert mock_download_extract.called
+        assert mock_download_extract.called_once_with(
+            urls=mock_dataset_class.urls,
+            dir_save=mock_dataset_class.data_path,
+            extract_data=mock_dataset_class.extract_data,
+            verbose=mock_dataset_class.verbose
+        )
 
     def test_process(self, mocker, mock_dataset_class):
         mock_parse_task = mocker.patch.object(BaseDatasetNew, "parse_task_name", return_value='taskA')


### PR DESCRIPTION
This PR addresses #124 and refactors the `BaseDataset` class as a new, temporary class for managing datasets called `BaseDatasetNew`. Once all datasets have been updated to use this new class, the new `BaseDatasetNew` will be renamed to `BaseDataset`. This allows to refactor dataset processing scripts without breaking stuff in the process.