### PR TITLE
[Refactor] modify BaseTask to simplify processing tasks of dataset

### DIFF
--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -349,13 +349,9 @@ class BaseTask(object):
 
     def setup_manager_hdf5(self):
         """Sets up the metadata manager to store the processed data to disk."""
-        self.hdf5_manager = self.set_hdf5_manager(self.hdf5_filepath)
         if self.verbose:
             print('\n==> Storing metadata to file: {}'.format(self.hdf5_filepath))
-
-    def set_hdf5_manager(self, hdf5_filepath):
-        """Sets a MetadataManager object to manage the metadata saving scheme to disk."""
-        pass
+        self.hdf5_manager = None
 
     def load_data(self):
         """Loads the dataset's (meta)data from disk (create a generator).

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import os
 import h5py
 
+from dbcollection.utils.hdf5 import HDF5Manager
 from dbcollection.utils.url import download_extract_all
 
 
@@ -482,7 +483,7 @@ class BaseTaskNew(object):
         """Sets up the metadata manager to store the processed data to disk."""
         if self.verbose:
             print('\n==> Storing metadata to file: {}'.format(self.hdf5_filepath))
-        self.hdf5_manager = None
+        self.hdf5_manager = HDF5Manager(filename=self.hdf5_filepath)
 
     def load_data(self):
         """Loads the dataset's (meta)data from disk (create a generator).

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -587,7 +587,22 @@ class BaseTaskNew(object):
             Name of the set split.
 
         """
-        pass  # TODO
+        for field in fields:
+            data = fields[field]
+            # TODO: check if the data is a method or a tuple/list/np.ndarray
+            self.add_field_data_to_hdf5(set_name, field, data)
+
+    def add_field_data_to_hdf5(self, group, field, data):
+        self.hdf5_manager.add_field_to_group(
+            group=group,
+            field=field,
+            data=data['data'],
+            dtype=data['dtype'],
+            fillvalue=data['fillvalue'],
+            chunks=data['chunks'],
+            compression=data['compression'],
+            compression_opts=data['compression_opts'],
+        )
 
     def teardown_hdf5_manager(self):
         """Sets up the MetadataManager object to manage the metadata save process to disk."""

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -298,9 +298,9 @@ class BaseTask(object):
     Attributes
     ----------
     data_path : str
-        Path to the data directory.
+        Path to the data directory of the dataset.
     cache_path : str
-        Path to the cache file
+        Path to store the HDF5 metadata file of a dataset in the cache directory.
     verbose : bool
         Displays text information to the screen (if true).
     filename_h5 : str

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -525,16 +525,24 @@ class BaseTaskNew(object):
         """
         pass
 
-    def add_field_data_to_hdf5(self, group, field, data):
+    def save_field_to_hdf5(self, set_name, field, data, **kwargs):
+        """Saves data of a field into the HDF% metadata file.
+
+        Parameters
+        ----------
+        set_name: str
+            Name of the set split.
+        field : str
+            Name of the data field.
+        data : np.ndarray
+            Numpy ndarray of the field's data.
+
+        """
         self.hdf5_manager.add_field_to_group(
-            group=group,
+            group=set_name,
             field=field,
-            data=data['data'],
-            dtype=data['dtype'],
-            fillvalue=data['fillvalue'],
-            chunks=data['chunks'],
-            compression=data['compression'],
-            compression_opts=data['compression_opts'],
+            data=data,
+            **kwargs
         )
 
     def teardown_hdf5_manager(self):

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -475,7 +475,6 @@ class BaseTaskNew(object):
         self.setup_manager_hdf5()
         data_generator = self.load_data()
         self.process_metadata(data_generator)
-        self.save_data_to_disk()
         self.teardown_manager_hdf5()
         return self.hdf5_filepath
 
@@ -506,10 +505,27 @@ class BaseTaskNew(object):
             for set_name in data:
                 if self.verbose:
                     print('\nSaving set metadata: {}'.format(set_name))
-                set_group = self.hdf5_create_group(set_name)
-                self.set_data_fields_to_save(set_group, data[set_name], set_name)
-                set_group_raw = self.hdf5_create_group(set_name + '/raw')
-                self.save_raw_metadata_to_hdf5(set_group_raw, data[set_name], set_name)
+                self.save_raw_metadata_to_hdf5(data[set_name], set_name)
+                fields = self.process_metadata_fields(data[set_name], set_name)
+                self.save_fields_to_hdf5(fields, set_name)
+
+    def save_raw_metadata_to_hdf5(self, data, set_name):
+        """Saves the dataset's metadata in its raw (original) format inside the HDF5 file.
+
+        Most datasets are set as nested trees of files + directories.
+        Here, the metadata of a dataset is stored in this fashion,
+        closely following the tree structure of the data.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary containing the data annotations of a set split.
+        set_name : str
+            Name of the set split.
+
+        """
+        group_raw = self.hdf5_create_group(set_name + '/raw')
+        self.save_raw_metadata(group_raw, data, set_name)
 
     def hdf5_create_group(self, group_name):
         """Creates a group in the HDF5 file.
@@ -522,8 +538,23 @@ class BaseTaskNew(object):
         """
         pass
 
-    def set_data_fields_to_save(self, hdf5_manager, data, set_name):
-        """Sets up which data fields to save in the HDF5 metadata file for a given set.
+    def save_raw_metadata(self, hdf5_handler, data, set_name):
+        """Saves the dataset's metadata in the raw (original) format.
+
+        Parameters
+        ----------
+        hdf5_handler : h5py._hl.group.Group
+            hdf5 group object handler.
+        data : dict
+            Dictionary containing the data annotations of a set split.
+        set_name : str
+            Name of the set split.
+
+        """
+        pass  # stub
+
+    def process_metadata_fields(self, data, set_name):
+        """Sets up which data fields to be saved in the HDF5 metadata file.
 
         All fields set in this method are organized as a single big matrix.
         This results in much faster data retrieval than by transversing nested
@@ -531,37 +562,31 @@ class BaseTaskNew(object):
 
         Parameters
         ----------
-        hdf5_handler : TODO
-            hdf5 group object handler.
         data : dict
             Dictionary containing the data annotations of a set split.
         set_name : str
             Name of the set split.
 
+        Returns
+        -------
+        dict
+            Dictionary with the field names as keys and the metadata as the respective value.
+
         """
         pass  # stub
 
-    def save_raw_metadata_to_hdf5(self, hdf5_manager, data, set_name):
-        """Saves the dataset's metadata in its raw (original) format inside the HDF5 file.
-
-        Most datasets are set as nested trees of files + directories.
-        Here, the metadata of a dataset is stored in this fashion,
-        closely following the tree structure of the data.
+    def save_fields_to_hdf5(self, fields, set_name):
+        """Saves the metadata of the processed fields to the HDF5 file for a set split.
 
         Parameters
         ----------
-        hdf5_handler : TODO
-            hdf5 group object handler.
-        data : dict
-            Dictionary containing the data annotations of a set split.
+        fields : dict
+            Dictionary containing fields with respective metadata annotations of a set split.
         set_name : str
             Name of the set split.
 
         """
-        pass  # stub
-
-    def save_data_to_disk(self):
-        pass
+        pass  # TODO
 
     def teardown_manager_hdf5(self):
         """Sets up the MetadataManager object to manage the metadata save process to disk."""

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -473,13 +473,13 @@ class BaseTaskNew(object):
         str
             File name + path of the task's HDF5 metadata file.
         """
-        self.setup_manager_hdf5()
+        self.setup_hdf5_manager()
         data_generator = self.load_data()
         self.process_metadata(data_generator)
-        self.teardown_manager_hdf5()
+        self.teardown_hdf5_manager()
         return self.hdf5_filepath
 
-    def setup_manager_hdf5(self):
+    def setup_hdf5_manager(self):
         """Sets up the metadata manager to store the processed data to disk."""
         if self.verbose:
             print('\n==> Storing metadata to file: {}'.format(self.hdf5_filepath))
@@ -589,6 +589,6 @@ class BaseTaskNew(object):
         """
         pass  # TODO
 
-    def teardown_manager_hdf5(self):
+    def teardown_hdf5_manager(self):
         """Sets up the MetadataManager object to manage the metadata save process to disk."""
         self.hdf5_manager.close()

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -506,56 +506,10 @@ class BaseTaskNew(object):
             for set_name in data:
                 if self.verbose:
                     print('\nSaving set metadata: {}'.format(set_name))
-                self.save_raw_metadata_to_hdf5(data[set_name], set_name)
-                fields = self.process_metadata_fields(data[set_name], set_name)
-                self.save_fields_to_hdf5(fields, set_name)
+                self.process_set_metadata(data[set_name], set_name)
 
-    def save_raw_metadata_to_hdf5(self, data, set_name):
-        """Saves the dataset's metadata in its raw (original) format inside the HDF5 file.
-
-        Most datasets are set as nested trees of files + directories.
-        Here, the metadata of a dataset is stored in this fashion,
-        closely following the tree structure of the data.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary containing the data annotations of a set split.
-        set_name : str
-            Name of the set split.
-
-        """
-        group_raw = self.hdf5_create_group(set_name + '/raw')
-        self.save_raw_metadata(group_raw, data, set_name)
-
-    def hdf5_create_group(self, group_name):
-        """Creates a group in the HDF5 file.
-
-        Parameters
-        ----------
-        group_name : str
-            Name of the group to be created in the HDF5 file.
-
-        """
-        pass
-
-    def save_raw_metadata(self, hdf5_handler, data, set_name):
-        """Saves the dataset's metadata in the raw (original) format.
-
-        Parameters
-        ----------
-        hdf5_handler : h5py._hl.group.Group
-            hdf5 group object handler.
-        data : dict
-            Dictionary containing the data annotations of a set split.
-        set_name : str
-            Name of the set split.
-
-        """
-        pass  # stub
-
-    def process_metadata_fields(self, data, set_name):
-        """Sets up which data fields to be saved in the HDF5 metadata file.
+    def process_set_metadata(self, data, set_name):
+        """Sets up the set's data fields to be stored in the HDF5 metadata file.
 
         All fields set in this method are organized as a single big matrix.
         This results in much faster data retrieval than by transversing nested
@@ -568,29 +522,8 @@ class BaseTaskNew(object):
         set_name : str
             Name of the set split.
 
-        Returns
-        -------
-        dict
-            Dictionary with the field names as keys and the metadata as the respective value.
-
         """
-        pass  # stub
-
-    def save_fields_to_hdf5(self, fields, set_name):
-        """Saves the metadata of the processed fields to the HDF5 file for a set split.
-
-        Parameters
-        ----------
-        fields : dict
-            Dictionary containing fields with respective metadata annotations of a set split.
-        set_name : str
-            Name of the set split.
-
-        """
-        for field in fields:
-            data = fields[field]
-            # TODO: check if the data is a method or a tuple/list/np.ndarray
-            self.add_field_data_to_hdf5(set_name, field, data)
+        pass
 
     def add_field_data_to_hdf5(self, group, field, data):
         self.hdf5_manager.add_field_to_group(

--- a/dbcollection/datasets/__init__.py
+++ b/dbcollection/datasets/__init__.py
@@ -284,6 +284,10 @@ class BaseDatasetNew(object):
 
 
 class BaseTask(object):
+    pass
+
+
+class BaseTaskNew(object):
     """Base class for processing the metadata of a task of a dataset.
 
     Parameters

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -217,3 +217,6 @@ class TestBaseTask:
         assert mock_save_data.called
         assert mock_teardown_manager.called
         assert filename == mock_task_class.hdf5_filepath
+
+    def test_setup_manager_hdf5(self, mocker, mock_task_class):
+        pass  # Todo

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -201,3 +201,19 @@ class TestBaseTask:
         filepath = mock_task_class.get_hdf5_save_filename()
 
         assert filepath == os.path.join('/path/to/cache', 'classification.h5')
+
+    def test_run(self, mocker, mock_task_class):
+        mock_setup_manager = mocker.patch.object(BaseTask, "setup_manager_hdf5")
+        mock_load_data = mocker.patch.object(BaseTask, "load_data", return_value={})
+        mock_process = mocker.patch.object(BaseTask, "process_metadata")
+        mock_save_data = mocker.patch.object(BaseTask, "save_data_to_disk")
+        mock_teardown_manager = mocker.patch.object(BaseTask, "teardown_manager_hdf5")
+
+        filename = mock_task_class.run()
+
+        assert mock_setup_manager.called
+        assert mock_load_data.called
+        assert mock_process.called
+        assert mock_save_data.called
+        assert mock_teardown_manager.called
+        assert filename == mock_task_class.hdf5_filepath

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -242,3 +242,18 @@ class TestBaseTask:
 
     def test_hdf5_create_group(self, mocker, mock_task_class):
         pass  # Todo
+
+    def test_set_data_fields_to_save(self, mocker, mock_task_class):
+        hdf5_manager = {}
+        data = ['dummy', 'data']
+        set_name = 'sample_set'
+
+        mock_task_class.set_data_fields_to_save(hdf5_manager, data, set_name)
+
+    def test_set_data_fields_to_save__raises_error_no_input_args(self, mocker, mock_task_class):
+        with pytest.raises(TypeError):
+            mock_task_class.set_data_fields_to_save()
+
+    def test_set_data_fields_to_save__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
+        with pytest.raises(TypeError):
+            mock_task_class.set_data_fields_to_save({}, ['dummy', 'data'])

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -275,3 +275,11 @@ class TestBaseTaskNew:
             compression="gzip",
             compression_opts=4
         )
+
+    def test_teardown_hdf5_manager(self, mocker, mock_task_class):
+        mock_add_field = mocker.Mock()
+        mock_task_class.hdf5_manager = mock_add_field
+
+        mock_task_class.teardown_hdf5_manager()
+
+        mock_add_field.close.assert_called_once_with()

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -3,6 +3,7 @@ Test the base classes for managing datasets and tasks.
 """
 
 
+import os
 import pytest
 
 from dbcollection.datasets import BaseDatasetNew, BaseTask
@@ -140,6 +141,15 @@ class TestBaseDatasetNew:
         assert result == 'some_data'
 
 
+@pytest.fixture()
+def mock_task_class(test_data):
+    return BaseTask(
+        data_path=test_data["data_path"],
+        cache_path=test_data["cache_path"],
+        verbose=test_data["verbose"]
+    )
+
+
 class TestBaseTask:
     """Unit tests for the BaseTask class."""
 
@@ -184,3 +194,10 @@ class TestBaseTask:
     def test_init__raises_error_too_many_input_args(self, mocker):
         with pytest.raises(TypeError):
             BaseTask('/path/to/data', '/path/to/cache', False, 'extra_input')
+
+    def test_get_hdf5_save_filename(self, mocker, mock_task_class):
+        mock_task_class.filename_h5 = 'classification'
+
+        filepath = mock_task_class.get_hdf5_save_filename()
+
+        assert filepath == os.path.join('/path/to/cache', 'classification.h5')

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -144,13 +144,43 @@ class TestBaseTask:
     """Unit tests for the BaseTask class."""
 
     def test_init_with_all_input_args(self, mocker):
-        pass
+        mock_get_filename = mocker.patch.object(BaseTask, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
+        data_path = '/path/to/data'
+        cache_path = '/path/to/cache'
+        verbose = True
+
+        task_manager = BaseTask(data_path=data_path,
+                                cache_path=cache_path,
+                                verbose=verbose)
+
+        assert mock_get_filename.called
+        assert task_manager.data_path == '/path/to/data'
+        assert task_manager.cache_path == '/path/to/cache'
+        assert task_manager.verbose == True
+        assert task_manager.hdf5_filepath == '/path/to/hdf5/file.h5'
+        assert task_manager.filename_h5 == ''
+        assert task_manager.hdf5_manager == None
 
     def test_init_withouth_optional_input_args(self, mocker):
-        pass
+        mock_get_filename = mocker.patch.object(BaseTask, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
+        data_path = '/path/to/data'
+        cache_path = '/path/to/cache'
+
+        task_manager = BaseTask(data_path=data_path,
+                                cache_path=cache_path)
+
+        assert mock_get_filename.called
+        assert task_manager.data_path == '/path/to/data'
+        assert task_manager.cache_path == '/path/to/cache'
+        assert task_manager.verbose == True
+        assert task_manager.hdf5_filepath == '/path/to/hdf5/file.h5'
+        assert task_manager.filename_h5 == ''
+        assert task_manager.hdf5_manager == None
 
     def test_init__raises_error_no_input_args(self, mocker):
-        pass
+        with pytest.raises(TypeError):
+            BaseTask()
 
     def test_init__raises_error_too_many_input_args(self, mocker):
-        pass
+        with pytest.raises(TypeError):
+            BaseTask('/path/to/data', '/path/to/cache', False, 'extra_input')

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -223,3 +223,19 @@ class TestBaseTask:
 
     def test_load_data(self, mocker, mock_task_class):
         mock_task_class.load_data()
+
+    def test_process_metadata(self, mocker, mock_task_class):
+        mock_create_group = mocker.patch.object(BaseTask, "hdf5_create_group", return_value={})
+        mock_set_data = mocker.patch.object(BaseTask, "set_data_fields_to_save")
+        mock_save_raw = mocker.patch.object(BaseTask, "save_raw_metadata_to_hdf5")
+
+        def sample_generator():
+            yield {'train': ['dummy', 'data']}
+            yield {'test': ['dummy', 'data']}
+        generator = sample_generator()
+
+        mock_task_class.process_metadata(generator)
+
+        assert mock_create_group.called
+        assert mock_set_data.called
+        assert mock_save_raw.called

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -257,3 +257,18 @@ class TestBaseTask:
     def test_set_data_fields_to_save__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
         with pytest.raises(TypeError):
             mock_task_class.set_data_fields_to_save({}, ['dummy', 'data'])
+
+    def test_save_raw_metadata_to_hdf5(self, mocker, mock_task_class):
+        hdf5_manager = {}
+        data = ['dummy', 'data']
+        set_name = 'sample_set'
+
+        mock_task_class.save_raw_metadata_to_hdf5(hdf5_manager, data, set_name)
+
+    def test_save_raw_metadata_to_hdf5__raises_error_no_input_args(self, mocker, mock_task_class):
+        with pytest.raises(TypeError):
+            mock_task_class.save_raw_metadata_to_hdf5()
+
+    def test_save_raw_metadata_to_hdf5__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
+        with pytest.raises(TypeError):
+            mock_task_class.save_raw_metadata_to_hdf5({}, ['dummy', 'data'])

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -206,7 +206,6 @@ class TestBaseTaskNew:
         mock_setup_manager = mocker.patch.object(BaseTaskNew, "setup_manager_hdf5")
         mock_load_data = mocker.patch.object(BaseTaskNew, "load_data", return_value={})
         mock_process = mocker.patch.object(BaseTaskNew, "process_metadata")
-        mock_save_data = mocker.patch.object(BaseTaskNew, "save_data_to_disk")
         mock_teardown_manager = mocker.patch.object(BaseTaskNew, "teardown_manager_hdf5")
 
         filename = mock_task_class.run()
@@ -214,7 +213,6 @@ class TestBaseTaskNew:
         assert mock_setup_manager.called
         assert mock_load_data.called
         assert mock_process.called
-        assert mock_save_data.called
         assert mock_teardown_manager.called
         assert filename == mock_task_class.hdf5_filepath
 
@@ -225,9 +223,9 @@ class TestBaseTaskNew:
         mock_task_class.load_data()
 
     def test_process_metadata(self, mocker, mock_task_class):
-        mock_create_group = mocker.patch.object(BaseTaskNew, "hdf5_create_group", return_value={})
-        mock_set_data = mocker.patch.object(BaseTaskNew, "set_data_fields_to_save")
         mock_save_raw = mocker.patch.object(BaseTaskNew, "save_raw_metadata_to_hdf5")
+        mock_process_metadata = mocker.patch.object(BaseTaskNew, "process_metadata_fields")
+        mock_save_fields = mocker.patch.object(BaseTaskNew, "save_fields_to_hdf5")
 
         def sample_generator():
             yield {'train': ['dummy', 'data']}
@@ -236,43 +234,21 @@ class TestBaseTaskNew:
 
         mock_task_class.process_metadata(generator)
 
+        assert mock_save_raw.called
+        assert mock_process_metadata.called
+        assert mock_save_fields.called
+
+    def test_save_raw_metadata_to_hdf5(self, mocker, mock_task_class):
+        mock_create_group = mocker.patch.object(BaseTaskNew, "hdf5_create_group", return_value={'dummy': 'object'})
+        mock_save_raw = mocker.patch.object(BaseTaskNew, "save_raw_metadata")
+
+        mock_task_class.save_raw_metadata_to_hdf5({'dummy': 'data'}, 'train')
+
         assert mock_create_group.called
-        assert mock_set_data.called
         assert mock_save_raw.called
 
     def test_hdf5_create_group(self, mocker, mock_task_class):
         pass  # Todo
 
-    def test_set_data_fields_to_save(self, mocker, mock_task_class):
-        hdf5_manager = {}
-        data = ['dummy', 'data']
-        set_name = 'sample_set'
-
-        mock_task_class.set_data_fields_to_save(hdf5_manager, data, set_name)
-
-    def test_set_data_fields_to_save__raises_error_no_input_args(self, mocker, mock_task_class):
-        with pytest.raises(TypeError):
-            mock_task_class.set_data_fields_to_save()
-
-    def test_set_data_fields_to_save__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
-        with pytest.raises(TypeError):
-            mock_task_class.set_data_fields_to_save({}, ['dummy', 'data'])
-
-    def test_save_raw_metadata_to_hdf5(self, mocker, mock_task_class):
-        hdf5_manager = {}
-        data = ['dummy', 'data']
-        set_name = 'sample_set'
-
-        mock_task_class.save_raw_metadata_to_hdf5(hdf5_manager, data, set_name)
-
-    def test_save_raw_metadata_to_hdf5__raises_error_no_input_args(self, mocker, mock_task_class):
-        with pytest.raises(TypeError):
-            mock_task_class.save_raw_metadata_to_hdf5()
-
-    def test_save_raw_metadata_to_hdf5__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
-        with pytest.raises(TypeError):
-            mock_task_class.save_raw_metadata_to_hdf5({}, ['dummy', 'data'])
-
-    def test_save_data_to_disk(self, mocker, mock_task_class):
-        pass
-
+    def test_save_fields_to_hdf5(self, mocker, mock_task_class):
+        pass  # TODO

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -239,3 +239,6 @@ class TestBaseTask:
         assert mock_create_group.called
         assert mock_set_data.called
         assert mock_save_raw.called
+
+    def test_hdf5_create_group(self, mocker, mock_task_class):
+        pass  # Todo

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -138,3 +138,19 @@ class TestBaseDatasetNew:
         result = mock_dataset_class.get_task_constructor(task)
 
         assert result == 'some_data'
+
+
+class TestBaseTask:
+    """Unit tests for the BaseTask class."""
+
+    def test_init_with_all_input_args(self, mocker):
+        pass
+
+    def test_init_withouth_optional_input_args(self, mocker):
+        pass
+
+    def test_init__raises_error_no_input_args(self, mocker):
+        pass
+
+    def test_init__raises_error_too_many_input_args(self, mocker):
+        pass

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -6,7 +6,7 @@ Test the base classes for managing datasets and tasks.
 import os
 import pytest
 
-from dbcollection.datasets import BaseDatasetNew, BaseTask
+from dbcollection.datasets import BaseDatasetNew, BaseTaskNew
 
 
 @pytest.fixture()
@@ -143,23 +143,23 @@ class TestBaseDatasetNew:
 
 @pytest.fixture()
 def mock_task_class(test_data):
-    return BaseTask(
+    return BaseTaskNew(
         data_path=test_data["data_path"],
         cache_path=test_data["cache_path"],
         verbose=test_data["verbose"]
     )
 
 
-class TestBaseTask:
-    """Unit tests for the BaseTask class."""
+class TestBaseTaskNew:
+    """Unit tests for the BaseTaskNew class."""
 
     def test_init_with_all_input_args(self, mocker):
-        mock_get_filename = mocker.patch.object(BaseTask, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
+        mock_get_filename = mocker.patch.object(BaseTaskNew, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
         verbose = True
 
-        task_manager = BaseTask(data_path=data_path,
+        task_manager = BaseTaskNew(data_path=data_path,
                                 cache_path=cache_path,
                                 verbose=verbose)
 
@@ -172,11 +172,11 @@ class TestBaseTask:
         assert task_manager.hdf5_manager == None
 
     def test_init_withouth_optional_input_args(self, mocker):
-        mock_get_filename = mocker.patch.object(BaseTask, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
+        mock_get_filename = mocker.patch.object(BaseTaskNew, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
 
-        task_manager = BaseTask(data_path=data_path,
+        task_manager = BaseTaskNew(data_path=data_path,
                                 cache_path=cache_path)
 
         assert mock_get_filename.called
@@ -189,11 +189,11 @@ class TestBaseTask:
 
     def test_init__raises_error_no_input_args(self, mocker):
         with pytest.raises(TypeError):
-            BaseTask()
+            BaseTaskNew()
 
     def test_init__raises_error_too_many_input_args(self, mocker):
         with pytest.raises(TypeError):
-            BaseTask('/path/to/data', '/path/to/cache', False, 'extra_input')
+            BaseTaskNew('/path/to/data', '/path/to/cache', False, 'extra_input')
 
     def test_get_hdf5_save_filename(self, mocker, mock_task_class):
         mock_task_class.filename_h5 = 'classification'
@@ -203,11 +203,11 @@ class TestBaseTask:
         assert filepath == os.path.join('/path/to/cache', 'classification.h5')
 
     def test_run(self, mocker, mock_task_class):
-        mock_setup_manager = mocker.patch.object(BaseTask, "setup_manager_hdf5")
-        mock_load_data = mocker.patch.object(BaseTask, "load_data", return_value={})
-        mock_process = mocker.patch.object(BaseTask, "process_metadata")
-        mock_save_data = mocker.patch.object(BaseTask, "save_data_to_disk")
-        mock_teardown_manager = mocker.patch.object(BaseTask, "teardown_manager_hdf5")
+        mock_setup_manager = mocker.patch.object(BaseTaskNew, "setup_manager_hdf5")
+        mock_load_data = mocker.patch.object(BaseTaskNew, "load_data", return_value={})
+        mock_process = mocker.patch.object(BaseTaskNew, "process_metadata")
+        mock_save_data = mocker.patch.object(BaseTaskNew, "save_data_to_disk")
+        mock_teardown_manager = mocker.patch.object(BaseTaskNew, "teardown_manager_hdf5")
 
         filename = mock_task_class.run()
 
@@ -225,9 +225,9 @@ class TestBaseTask:
         mock_task_class.load_data()
 
     def test_process_metadata(self, mocker, mock_task_class):
-        mock_create_group = mocker.patch.object(BaseTask, "hdf5_create_group", return_value={})
-        mock_set_data = mocker.patch.object(BaseTask, "set_data_fields_to_save")
-        mock_save_raw = mocker.patch.object(BaseTask, "save_raw_metadata_to_hdf5")
+        mock_create_group = mocker.patch.object(BaseTaskNew, "hdf5_create_group", return_value={})
+        mock_set_data = mocker.patch.object(BaseTaskNew, "set_data_fields_to_save")
+        mock_save_raw = mocker.patch.object(BaseTaskNew, "save_raw_metadata_to_hdf5")
 
         def sample_generator():
             yield {'train': ['dummy', 'data']}

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -272,3 +272,7 @@ class TestBaseTask:
     def test_save_raw_metadata_to_hdf5__raises_error_missing_one_input_arg(self, mocker, mock_task_class):
         with pytest.raises(TypeError):
             mock_task_class.save_raw_metadata_to_hdf5({}, ['dummy', 'data'])
+
+    def test_save_data_to_disk(self, mocker, mock_task_class):
+        pass
+

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -54,7 +54,7 @@ class TestBaseDatasetNew:
         assert db_manager.tasks == {}
         assert db_manager.default_task == ''
 
-    def test_init_withouth_optional_input_args(self, mocker):
+    def test_init_without_optional_input_args(self, mocker):
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
 
@@ -171,7 +171,7 @@ class TestBaseTaskNew:
         assert task_manager.filename_h5 == ''
         assert task_manager.hdf5_manager == None
 
-    def test_init_withouth_optional_input_args(self, mocker):
+    def test_init_without_optional_input_args(self, mocker):
         mock_get_filename = mocker.patch.object(BaseTaskNew, "get_hdf5_save_filename", return_value='/path/to/hdf5/file.h5')
         data_path = '/path/to/data'
         cache_path = '/path/to/cache'
@@ -203,10 +203,10 @@ class TestBaseTaskNew:
         assert filepath == os.path.join('/path/to/cache', 'classification.h5')
 
     def test_run(self, mocker, mock_task_class):
-        mock_setup_manager = mocker.patch.object(BaseTaskNew, "setup_manager_hdf5")
+        mock_setup_manager = mocker.patch.object(BaseTaskNew, "setup_hdf5_manager")
         mock_load_data = mocker.patch.object(BaseTaskNew, "load_data", return_value={})
         mock_process = mocker.patch.object(BaseTaskNew, "process_metadata")
-        mock_teardown_manager = mocker.patch.object(BaseTaskNew, "teardown_manager_hdf5")
+        mock_teardown_manager = mocker.patch.object(BaseTaskNew, "teardown_hdf5_manager")
 
         filename = mock_task_class.run()
 
@@ -215,9 +215,6 @@ class TestBaseTaskNew:
         assert mock_process.called
         assert mock_teardown_manager.called
         assert filename == mock_task_class.hdf5_filepath
-
-    def test_setup_manager_hdf5(self, mocker, mock_task_class):
-        pass  # Todo
 
     def test_load_data(self, mocker, mock_task_class):
         mock_task_class.load_data()

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -5,6 +5,7 @@ Test the base classes for managing datasets and tasks.
 
 import os
 import pytest
+import numpy as np
 
 from dbcollection.datasets import BaseDatasetNew, BaseTaskNew
 
@@ -248,4 +249,42 @@ class TestBaseTaskNew:
         pass  # Todo
 
     def test_save_fields_to_hdf5(self, mocker, mock_task_class):
-        pass  # TODO
+        mock_add_data = mocker.patch.object(BaseTaskNew, "add_field_data_to_hdf5")
+        set_name = 'train'
+        fields = {
+            "fieldA": "dummy_dataA",
+            "fieldB": "dummy_dataB",
+            "fieldC": "dummy_dataC",
+        }
+
+        mock_task_class.save_fields_to_hdf5(fields, set_name)
+
+        assert mock_add_data.called
+        assert mock_add_data.call_count == len(fields)
+
+    def test_add_field_data_to_hdf5(self, mocker, mock_task_class):
+        mock_add_field = mocker.Mock()
+        mock_task_class.hdf5_manager = mock_add_field
+
+        group = 'train'
+        field = 'fieldA'
+        data = {
+            "data": np.array(range(10)),
+            "dtype": np.uint8,
+            "fillvalue": 0,
+            "chunks": True,
+            "compression": "gzip",
+            "compression_opts": 4
+        }
+        mock_task_class.add_field_data_to_hdf5(group, field, data)
+
+        mock_add_field.add_field_to_group.assert_called_once_with(
+            group='train',
+            field='fieldA',
+            data=data['data'],
+            dtype=data['dtype'],
+            fillvalue=data['fillvalue'],
+            chunks=data['chunks'],
+            compression=data['compression'],
+            compression_opts=data['compression_opts'],
+        )

--- a/dbcollection/tests/datasets/test_base_classes.py
+++ b/dbcollection/tests/datasets/test_base_classes.py
@@ -220,3 +220,6 @@ class TestBaseTask:
 
     def test_setup_manager_hdf5(self, mocker, mock_task_class):
         pass  # Todo
+
+    def test_load_data(self, mocker, mock_task_class):
+        mock_task_class.load_data()


### PR DESCRIPTION
This PR addresses #124 and refactors `BaseTask` to simplify processing tasks of datasets. A temporary class `BaseTaskNew` was created to deal with the transition to the new way to process metadata such that datasets using the old `BaseTask` class don't break.