### PR TITLE
[Refactor] mnist dataset using the refactored BaseDataset and BaseTask classes

### DIFF
--- a/dbcollection/core/api/download.py
+++ b/dbcollection/core/api/download.py
@@ -181,4 +181,4 @@ class DownloadAPI(object):
         self.cache_manager.dataset.update(self.name, data_dir=data_dir)
 
     def add_dataset_info_to_cache(self, data_dir):
-        self.cache_manager.dataset.add(self.name, data_dir=self.save_data_dir, tasks={})
+        self.cache_manager.dataset.add(self.name, data_dir=self.data_dir, tasks={})

--- a/dbcollection/core/api/load.py
+++ b/dbcollection/core/api/load.py
@@ -162,7 +162,7 @@ class LoadAPI(object):
         self.cache_manager.manager.reload_cache()
 
     def dataset_task_metadata_exists_in_cache(self):
-        return self.cache_manager.task.exists(self.name, self.task)
+        return self.cache_manager.task.exists(task=self.task, name=self.name)
 
     def process_dataset_task_metadata(self):
         self.process_dataset()

--- a/dbcollection/core/manager.py
+++ b/dbcollection/core/manager.py
@@ -263,7 +263,7 @@ class CacheDataManager:
         """
         assert name, "Must input a valid dataset name."
         assert data_dir, "Must input a valid data directory."
-        assert tasks, "Must input a valid tasks."
+        assert tasks is not None, "Must input a valid tasks."
 
         new_data = {
             "data_dir": data_dir,
@@ -410,7 +410,7 @@ class CacheManagerDataset:
         """
         assert name, "Must input a valid dataset name."
         assert data_dir, "Must input a valid directory (data_dir)."
-        assert tasks, "Must input a valid tasks."
+        assert tasks is not None, "Must input a valid tasks."
 
         self.manager.add_data(name, data_dir, tasks)
 

--- a/dbcollection/datasets/mnist/README.rst
+++ b/dbcollection/datasets/mnist/README.rst
@@ -6,7 +6,7 @@ MNIST Handwritten Digit Database
 
 The **MNIST** database of handwritten digits has a
 training set of 60,000 examples, and a test set of 10,000 examples. It is a
-subset of a larger set available from **NIST**.
+subset of a larger set available from **MNIST**.
 The digits have been size-normalized and centered in a fixed-size image.
 
 
@@ -23,22 +23,62 @@ Properties
 - ``keywords``: image_processing, classification
 - ``dataset size``: 11,6 MB
 - ``is downloadable``: **yes**
-- ``tasks``:
-    - classification: **(default)**
-        - ``primary use``: image classification
-        - ``description``: Contains image tensors and label annotations for image classification.
-        - ``sets``: train, test
-        - ``metadata file size in disk``: 6,8 MB
-        - ``has annotations``: **yes**
-            - ``which``:
-                - labels for each image class/category.
+- ``tasks``: :ref:`classification (default) <mnist_readme_classification>`
 
 
-Metadata structure (HDF5)
-=========================
+Tasks
+=====
 
-Task: classification
---------------------
+.. _mnist_readme_classification:
+
+classification (default)
+------------------------
+
+- :ref:`How to use <classification_how_to_use>`
+- :ref:`Properties <classification_properties>`
+- :ref:`HDF5 file structure <classification_hdf5_file_structure>`
+- :ref:`Fields <classification_fields>`
+
+.. _classification_how_to_use:
+
+How to use
+^^^^^^^^^^
+
+.. code-block:: python
+
+    >>> # import the package
+    >>> import dbcollection as dbc
+    >>>
+    >>> # load the dataset
+    >>> mnist = dbc.load('mnist', 'classification')
+    >>> mnist
+    DataLoader: "mnist" (classification task)
+
+
+.. _classification_properties:
+
+Properties
+^^^^^^^^^^
+
+- ``primary use``: image classification
+- ``description``: Contains image tensors and label annotations for image classification.
+- ``sets``: train, test
+- ``metadata file size in disk``: 6,8 MB
+- ``has annotations``: **yes**
+    - ``which``:
+        - labels for each image class/category.
+- ``available fields``:
+    - :ref:`classes <classification_fields_classes>`
+    - :ref:`images <classification_fields_images>`
+    - :ref:`labels <classification_fields_labels>`
+    - :ref:`object_fields <classification_fields_object_fields>`
+    - :ref:`object_ids <classification_fields_object_ids>`
+    - :ref:`list_images_per_class <classification_fields_list_images_per_class>`
+
+.. _classification_hdf5_file_structure:
+
+HDF5 file structure
+^^^^^^^^^^^^^^^^^^^
 
 ::
 
@@ -60,8 +100,12 @@ Task: classification
         └── list_images_per_class   # dtype=np.int32, shape=(10,1135))
 
 
+.. _classification_fields:
+
 Fields
 ^^^^^^
+
+.. _classification_fields_classes:
 
 - ``classes``: class names
     - ``available in``: train, test
@@ -69,16 +113,25 @@ Fields
     - ``is padded``: True
     - ``fill value``: 0
     - ``note``: strings stored in ASCII format
+
+.. _classification_fields_images:
+
 - ``images``: images tensor
     - ``available in``: train, test
     - ``dtype``: np.uint8
     - ``is padded``: False
     - ``fill value``: -1
+
+.. _classification_fields_labels:
+
 - ``labels``: class ids
     - ``available in``: train, test
     - ``dtype``: np.uint8
     - ``is padded``: False
     - ``fill value``: -1
+
+.. _classification_fields_object_fields:
+
 - ``object_fields``: list of field names of the object id list
     - ``available in``: train, test
     - ``dtype``: np.uint8
@@ -86,12 +139,18 @@ Fields
     - ``fill value``: 0
     - ``note``: strings stored in ASCII format
     - ``note``: key field (*field name* aggregator)
+
+.. _classification_fields_object_ids:
+
 - ``object_ids``: list of field ids
     - ``available in``: train, test
     - ``dtype``: np.int32
     - ``is padded``: False
     - ``fill value``: -1
     - ``note``: key field (*field id* aggregator)
+
+.. _classification_fields_list_images_per_class:
+
 - ``list_images_per_class``: list of image ids per class
     - ``available in``: train, test
     - ``dtype``: np.int32

--- a/dbcollection/datasets/mnist/__init__.py
+++ b/dbcollection/datasets/mnist/__init__.py
@@ -10,6 +10,7 @@ import shutil
 from dbcollection.datasets import BaseDataset
 from .classification import Classification
 
+
 urls = (
     "http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz",
     "http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz",

--- a/dbcollection/datasets/mnist/__init__.py
+++ b/dbcollection/datasets/mnist/__init__.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 import os
 import shutil
 
-from dbcollection.datasets import BaseDataset
+from dbcollection.datasets import BaseDatasetNew
 from .classification import Classification
 
 
@@ -22,7 +22,7 @@ tasks = {"classification": Classification}
 default_task = 'classification'
 
 
-class Dataset(BaseDataset):
+class Dataset(BaseDatasetNew):
     """MNIST preprocessing/downloading functions."""
     urls = urls
     keywords = keywords

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -7,19 +7,62 @@ from __future__ import print_function, division
 import os
 import numpy as np
 
-from dbcollection.datasets import BaseTask
+from dbcollection.datasets import BaseTaskNew
 from dbcollection.utils.string_ascii import convert_str_to_ascii as str2ascii
 from dbcollection.utils.pad import pad_list
-from dbcollection.utils.hdf5 import hdf5_write_data
 
 
-class Classification(BaseTask):
+class Classification(BaseTaskNew):
     """MNIST Classification preprocessing functions."""
 
     # metadata filename
     filename_h5 = 'classification'
 
     classes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+    def load_data(self):
+        """
+        Load the data from the files.
+        """
+        yield {"train": self.load_data_train()}
+        yield {"test": self.load_data_test()}
+
+    def load_data_train(self):
+        """
+        Fetch train data.
+        """
+        train_images, train_labels, size_train = self.get_train_data()
+
+        train_data = train_images.reshape(size_train, 28, 28)
+        train_object_list = np.array([[i, train_labels[i]] for i in range(size_train)])
+        classes = str2ascii(self.classes)
+
+        return {
+            "classes": classes,
+            "images": train_data,
+            "labels": train_labels,
+            "object_fields": str2ascii(['images', 'labels']),
+            "object_ids": train_object_list,
+            "list_images_per_class": self.get_list_images_per_class(train_labels)
+        }
+
+    def get_train_data(self):
+        """Loads the data of the train set."""
+        fname_train_imgs = os.path.join(self.data_path, 'train-images.idx3-ubyte')
+        fname_train_lbls = os.path.join(self.data_path, 'train-labels.idx1-ubyte')
+        train_images = self.load_images_numpy(fname_train_imgs)
+        train_labels = self.load_labels_numpy(fname_train_lbls)
+        size_train = 60000
+        return train_images, train_labels, size_train
+
+    def get_list_images_per_class(self, set_labels):
+        """Builds a list of images per class."""
+        images_per_class = []
+        labels = np.unique(set_labels)
+        for label in labels:
+            images_idx = np.where(set_labels == label)[0].tolist()
+            images_per_class.append(images_idx)
+        return np.array(pad_list(images_per_class, 1), dtype=np.int32)
 
     def load_images_numpy(self, fname):
         """Load images from file as numpy array."""
@@ -35,74 +78,15 @@ class Classification(BaseTask):
             data = np.fromfile(f, dtype=np.int8)
         return data
 
-    def load_data_train(self):
-        """
-        Fetch train data.
-        """
-        # files path
-        fname_train_imgs = os.path.join(self.data_path, 'train-images.idx3-ubyte')
-        fname_train_lbls = os.path.join(self.data_path, 'train-labels.idx1-ubyte')
-
-        # read files to memory
-        train_images = self.load_images_numpy(fname_train_imgs)
-        train_labels = self.load_labels_numpy(fname_train_lbls)
-
-        size_train = 60000
-
-        # reshape images
-        train_data = train_images.reshape(size_train, 28, 28)
-
-        # get object_id lists
-        train_object_list = np.array([[i, train_labels[i]] for i in range(size_train)])
-
-        # classes
-        classes = str2ascii(self.classes)
-
-        # organize list of image indexes per class
-        train_images_per_class = []
-        labels = np.unique(train_labels)
-        for label in labels:
-            tr_images_idx = np.where(train_labels == label)[0].tolist()
-            train_images_per_class.append(tr_images_idx)
-
-        return {
-            "classes": classes,
-            "images": train_data,
-            "labels": train_labels,
-            "object_fields": str2ascii(['images', 'labels']),
-            "object_ids": train_object_list,
-            "list_images_per_class": np.array(pad_list(train_images_per_class, 1), dtype=np.int32)
-        }
-
     def load_data_test(self):
         """
         Fetch test data.
         """
-        # files path
-        fname_test_imgs = os.path.join(self.data_path, 't10k-images.idx3-ubyte')
-        fname_test_lbls = os.path.join(self.data_path, 't10k-labels.idx1-ubyte')
+        test_images, test_labels, size_test = self.get_test_data()
 
-        # read files to memory
-        test_images = self.load_images_numpy(fname_test_imgs)
-        test_labels = self.load_labels_numpy(fname_test_lbls)
-
-        size_test = 10000
-
-        # reshape images
         test_data = test_images.reshape(size_test, 28, 28)
-
-        # get object_id lists
         test_object_list = np.array([[i, test_labels[i]] for i in range(size_test)])
-
-        # classes
         classes = str2ascii(self.classes)
-
-        # organize list of image indexes per class
-        test_images_per_class = []
-        labels = np.unique(test_labels)
-        for label in labels:
-            ts_images_idx = np.where(test_labels == label)[0].tolist()
-            test_images_per_class.append(ts_images_idx)
 
         return {
             "classes": classes,
@@ -110,49 +94,31 @@ class Classification(BaseTask):
             "labels": test_labels,
             "object_fields": str2ascii(['images', 'labels']),
             "object_ids": test_object_list,
-            "list_images_per_class": np.array(pad_list(test_images_per_class, 1), dtype=np.int32)
+            "list_images_per_class": self.get_list_images_per_class(test_labels)
         }
 
-    def load_data(self):
-        """
-        Load the data from the files.
-        """
-        # train set
-        yield {"train": self.load_data_train()}
+    def get_test_data(self):
+        """Loads the data of the test set."""
+        fname_test_imgs = os.path.join(self.data_path, 't10k-images.idx3-ubyte')
+        fname_test_lbls = os.path.join(self.data_path, 't10k-labels.idx1-ubyte')
+        test_images = self.load_images_numpy(fname_test_imgs)
+        test_labels = self.load_labels_numpy(fname_test_lbls)
+        size_test = 10000
+        return test_images, test_labels, size_test
 
-        # test set
-        yield {"test": self.load_data_test()}
-
-    def add_data_to_source(self, hdf5_handler, data, set_name=None):
+    def process_set_metadata(self, data, set_name):
         """
-        Store data annotations in a nested tree fashion.
-
-        It closely follows the tree structure of the data.
+        Saves the metadata of a set.
         """
-        hdf5_write_data(hdf5_handler, 'images', data["images"], dtype=np.uint8, fillvalue=-1)
-        hdf5_write_data(hdf5_handler, 'labels', data["labels"], dtype=np.uint8, fillvalue=0)
-
-    def add_data_to_default(self, hdf5_handler, data, set_name=None):
-        """
-        Add data of a set to the default group.
-
-        For each field, the data is organized into a single big matrix.
-        """
-        hdf5_write_data(hdf5_handler, 'classes',
-                        data["classes"], dtype=np.uint8,
-                        fillvalue=0)
-        hdf5_write_data(hdf5_handler, 'images',
-                        data["images"], dtype=np.uint8,
-                        fillvalue=-1)
-        hdf5_write_data(hdf5_handler, 'labels',
-                        data["labels"], dtype=np.uint8,
-                        fillvalue=0)
-        hdf5_write_data(hdf5_handler, 'object_fields',
-                        data["object_fields"], dtype=np.uint8,
-                        fillvalue=0)
-        hdf5_write_data(hdf5_handler, 'object_ids',
-                        data["object_ids"], dtype=np.int32,
-                        fillvalue=-1)
-        hdf5_write_data(hdf5_handler, 'list_images_per_class',
-                        data["list_images_per_class"], dtype=np.int32,
-                        fillvalue=-1)
+        self.save_field_to_hdf5(set_name, 'classes', data["classes"],
+                                dtype=np.uint8, fillvalue=0)
+        self.save_field_to_hdf5(set_name, 'images', data["images"],
+                                dtype=np.uint8, fillvalue=-1)
+        self.save_field_to_hdf5(set_name, 'labels', data["labels"],
+                                dtype=np.uint8, fillvalue=0)
+        self.save_field_to_hdf5(set_name, 'object_fields', data["object_fields"],
+                                dtype=np.uint8, fillvalue=0)
+        self.save_field_to_hdf5(set_name, 'object_ids', data["object_ids"],
+                                dtype=np.int32, fillvalue=-1)
+        self.save_field_to_hdf5(set_name, 'list_images_per_class', data["list_images_per_class"],
+                                dtype=np.int32, fillvalue=-1)


### PR DESCRIPTION
This PR addresses #126 and refactors the `MNIST`  dataset + task processing and refactors its docs. 

The loading and processing of data is less convoluted after the refactor. Because of this, the `mnist` dataset setup will be used as reference for the other datasets + tasks because it is much simpler to read this new code for setting up a dataset/tasks.