### PR TITLE
[Feature] add uni tests to the mnist dataset

### DIFF
--- a/dbcollection/datasets/mnist/README.rst
+++ b/dbcollection/datasets/mnist/README.rst
@@ -75,6 +75,7 @@ Properties
     - :ref:`object_ids <classification_fields_object_ids>`
     - :ref:`list_images_per_class <classification_fields_list_images_per_class>`
 
+
 .. _classification_hdf5_file_structure:
 
 HDF5 file structure

--- a/dbcollection/datasets/mnist/__init__.py
+++ b/dbcollection/datasets/mnist/__init__.py
@@ -3,7 +3,6 @@ MNIST download/process functions.
 """
 
 
-from __future__ import print_function, division
 import os
 import shutil
 

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -62,7 +62,7 @@ class Classification(BaseTaskNew):
         for label in labels:
             images_idx = np.where(set_labels == label)[0].tolist()
             images_per_class.append(images_idx)
-        return np.array(pad_list(images_per_class, 1), dtype=np.int32)
+        return np.array(pad_list(images_per_class, -1), dtype=np.int32)
 
     def load_images_numpy(self, fname):
         """Load images from file as numpy array."""

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -50,25 +50,6 @@ class Classification(BaseTaskNew):
             "list_images_per_class": self.get_list_images_per_class(labels)
         }
 
-    def load_data_train(self):
-        """
-        Fetch train data.
-        """
-        train_images, train_labels, size_train = self.get_train_data()
-
-        train_data = train_images.reshape(size_train, 28, 28)
-        train_object_list = np.array([[i, train_labels[i]] for i in range(size_train)])
-        classes = str2ascii(self.classes)
-
-        return {
-            "classes": classes,
-            "images": train_data,
-            "labels": train_labels,
-            "object_fields": str2ascii(['images', 'labels']),
-            "object_ids": train_object_list,
-            "list_images_per_class": self.get_list_images_per_class(train_labels)
-        }
-
     def get_train_data(self):
         """Loads the data of the train set."""
         fname_train_imgs = os.path.join(self.data_path, 'train-images.idx3-ubyte')

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -82,25 +82,6 @@ class Classification(BaseTaskNew):
             data = np.fromfile(f, dtype=np.int8)
         return data
 
-    def load_data_test(self):
-        """
-        Fetch test data.
-        """
-        test_images, test_labels, size_test = self.get_test_data()
-
-        test_data = test_images.reshape(size_test, 28, 28)
-        test_object_list = np.array([[i, test_labels[i]] for i in range(size_test)])
-        classes = str2ascii(self.classes)
-
-        return {
-            "classes": classes,
-            "images": test_data,
-            "labels": test_labels,
-            "object_fields": str2ascii(['images', 'labels']),
-            "object_ids": test_object_list,
-            "list_images_per_class": self.get_list_images_per_class(test_labels)
-        }
-
     def get_test_data(self):
         """Loads the data of the test set."""
         fname_test_imgs = os.path.join(self.data_path, 't10k-images.idx3-ubyte')

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -22,7 +22,7 @@ class Classification(BaseTaskNew):
 
     def load_data(self):
         """
-        Load the data from the files.
+        Loads data from annotation files.
         """
         yield {"train": self.load_data_train()}
         yield {"test": self.load_data_test()}
@@ -56,7 +56,7 @@ class Classification(BaseTaskNew):
         return train_images, train_labels, size_train
 
     def get_list_images_per_class(self, set_labels):
-        """Builds a list of images per class."""
+        """Builds a list of image indexes per class."""
         images_per_class = []
         labels = np.unique(set_labels)
         for label in labels:

--- a/dbcollection/datasets/mnist/classification.py
+++ b/dbcollection/datasets/mnist/classification.py
@@ -24,8 +24,31 @@ class Classification(BaseTaskNew):
         """
         Loads data from annotation files.
         """
-        yield {"train": self.load_data_train()}
-        yield {"test": self.load_data_test()}
+        yield {"train": self.load_data_set(is_test=False)}
+        yield {"test": self.load_data_set(is_test=True)}
+
+    def load_data_set(self, is_test):
+        """
+        Fetches the train/test data.
+        """
+        assert isinstance(is_test, bool), "Must input a valid boolean input."
+        if is_test:
+            images, labels, size_set = self.get_test_data()
+        else:
+            images, labels, size_set = self.get_train_data()
+
+        data = images.reshape(size_set, 28, 28)
+        object_list = np.array([[i, labels[i]] for i in range(size_set)])
+        classes = str2ascii(self.classes)
+
+        return {
+            "classes": classes,
+            "images": data,
+            "labels": labels,
+            "object_fields": str2ascii(['images', 'labels']),
+            "object_ids": object_list,
+            "list_images_per_class": self.get_list_images_per_class(labels)
+        }
 
     def load_data_train(self):
         """

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -4,6 +4,7 @@ Test the base classes for managing datasets and tasks.
 
 
 import os
+import sys
 import pytest
 import numpy as np
 
@@ -22,3 +23,20 @@ class TestClassificationTask:
         assert mock_classification_class.filename_h5 == 'classification'
         classes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
         assert mock_classification_class.classes == classes
+
+    def test_load_data(self, mocker, mock_classification_class):
+        mock_load_data_train = mocker.patch.object(Classification, "load_data_train", return_value=['some_train_data'])
+        mock_load_data_test = mocker.patch.object(Classification, "load_data_test", return_value=['some_test_data'])
+
+        load_data_generator = mock_classification_class.load_data()
+        if sys.version[0] == '3':
+            train_data = load_data_generator.__next__()
+            test_data = load_data_generator.__next__()
+        else:
+            train_data = load_data_generator.next()
+            test_data = load_data_generator.next()
+
+        mock_load_data_train.assert_called_once_with()
+        mock_load_data_test.assert_called_once_with()
+        assert train_data == {"train": ['some_train_data']}
+        assert test_data == {"test": ['some_test_data']}

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -31,8 +31,7 @@ class TestClassificationTask:
         assert mock_classification_class.classes == classes_classification
 
     def test_load_data(self, mocker, mock_classification_class):
-        mock_load_data_train = mocker.patch.object(Classification, "load_data_train", return_value=['some_train_data'])
-        mock_load_data_test = mocker.patch.object(Classification, "load_data_test", return_value=['some_test_data'])
+        mock_load_data = mocker.patch.object(Classification, "load_data_set", return_value=['some_data'])
 
         load_data_generator = mock_classification_class.load_data()
         if sys.version[0] == '3':
@@ -42,10 +41,9 @@ class TestClassificationTask:
             train_data = load_data_generator.next()
             test_data = load_data_generator.next()
 
-        mock_load_data_train.assert_called_once_with()
-        mock_load_data_test.assert_called_once_with()
-        assert train_data == {"train": ['some_train_data']}
-        assert test_data == {"test": ['some_test_data']}
+        assert mock_load_data.called
+        assert train_data == {"train": ['some_data']}
+        assert test_data == {"test": ['some_data']}
 
     def test_load_data_train(self, mocker, mock_classification_class, classes_classification):
         images, labels, size_train = (np.random.rand(10, 784), np.array(range(10)), 10)

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -101,3 +101,13 @@ class TestClassificationTask:
         assert_array_equal(test_images, np.zeros((5,768)))
         assert_array_equal(test_labels, np.ones(5))
         assert size_test == 10000
+
+    def test_process_set_metadata(self, mocker, mock_classification_class):
+        mock_save_hdf5 = mocker.patch.object(Classification, "save_field_to_hdf5")
+
+        data = {"classes": 1, "images": 1, "labels": 1,
+                "object_fields": 1, "object_ids": 1, "list_images_per_class": 1}
+        mock_classification_class.process_set_metadata(data, 'train')
+
+        assert mock_save_hdf5.called
+        assert mock_save_hdf5.call_count == 6

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -89,3 +89,15 @@ class TestClassificationTask:
                              [0, 1, 2, 3, 5, 6]],
                              dtype=np.int32)
         assert_array_equal(images_per_class, expected)
+
+    def test_get_test_data(self, mocker, mock_classification_class):
+        mock_load_images = mocker.patch.object(Classification, "load_images_numpy", return_value=np.zeros((5,768)))
+        mock_load_labels = mocker.patch.object(Classification, "load_labels_numpy", return_value=np.ones(5))
+
+        test_images, test_labels, size_test = mock_classification_class.get_test_data()
+
+        mock_load_images.assert_called_once_with('/some/path/data/t10k-images.idx3-ubyte')
+        mock_load_labels.assert_called_once_with('/some/path/data/t10k-labels.idx1-ubyte')
+        assert_array_equal(test_images, np.zeros((5,768)))
+        assert_array_equal(test_labels, np.ones(5))
+        assert size_test == 10000

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -74,3 +74,13 @@ class TestClassificationTask:
         assert_array_equal(train_images, np.zeros((5,768)))
         assert_array_equal(train_labels, np.ones(5))
         assert size_train == 60000
+
+    def test_get_list_images_per_class(self, mocker, mock_classification_class):
+        labels = np.array([1,1,1,1,0,1,1,0])
+
+        images_per_class = mock_classification_class.get_list_images_per_class(labels)
+
+        expected = np.array([[4, 7, -1, -1, -1, -1],
+                             [0, 1, 2, 3, 5, 6]],
+                             dtype=np.int32)
+        assert_array_equal(images_per_class, expected)

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -26,10 +26,9 @@ def classes_classification():
 class TestClassificationTask:
     """Unit tests for the mnist Classification task."""
 
-    def test_task_attributes(self, mocker, mock_classification_class):
+    def test_task_attributes(self, mocker, mock_classification_class, classes_classification):
         assert mock_classification_class.filename_h5 == 'classification'
-        classes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
-        assert mock_classification_class.classes == classes
+        assert mock_classification_class.classes == classes_classification
 
     def test_load_data(self, mocker, mock_classification_class):
         mock_load_data_train = mocker.patch.object(Classification, "load_data_train", return_value=['some_train_data'])

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -62,3 +62,15 @@ class TestClassificationTask:
         assert_array_equal(set_data['object_fields'], str2ascii(['images', 'labels']))
         assert_array_equal(set_data['object_ids'], np.array([[i, labels[i]] for i in range(size_train)]))
         assert set_data['list_images_per_class'] == list(range(10))
+
+    def test_get_train_data(self, mocker, mock_classification_class):
+        mock_load_images = mocker.patch.object(Classification, "load_images_numpy", return_value=np.zeros((5,768)))
+        mock_load_labels = mocker.patch.object(Classification, "load_labels_numpy", return_value=np.ones(5))
+
+        train_images, train_labels, size_train = mock_classification_class.get_train_data()
+
+        mock_load_images.assert_called_once_with('/some/path/data/train-images.idx3-ubyte')
+        mock_load_labels.assert_called_once_with('/some/path/data/train-labels.idx1-ubyte')
+        assert_array_equal(train_images, np.zeros((5,768)))
+        assert_array_equal(train_labels, np.ones(5))
+        assert size_train == 60000

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -10,7 +10,15 @@ import numpy as np
 from dbcollection.datasets.mnist import Classification
 
 
+@pytest.fixture()
+def mock_classification_class():
+    return Classification(data_path='/some/path/data', cache_path='/some/path/cache')
+
+
 class TestClassificationTask:
     """Unit tests for the mnist Classification task."""
 
-    pass
+    def test_task_attributes(self, mocker, mock_classification_class):
+        assert mock_classification_class.filename_h5 == 'classification'
+        classes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+        assert mock_classification_class.classes == classes

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -1,0 +1,16 @@
+"""
+Test the base classes for managing datasets and tasks.
+"""
+
+
+import os
+import pytest
+import numpy as np
+
+from dbcollection.datasets.mnist import Classification
+
+
+class TestClassificationTask:
+    """Unit tests for the mnist Classification task."""
+
+    pass

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -68,22 +68,6 @@ class TestClassificationTask:
         assert_array_equal(set_data['object_ids'], np.array([[i, labels[i]] for i in range(size_set)]))
         assert set_data['list_images_per_class'] == list(range(10))
 
-    def test_load_data_train(self, mocker, mock_classification_class, classes_classification):
-        images, labels, size_train = (np.random.rand(10, 784), np.array(range(10)), 10)
-        mock_get_data_train= mocker.patch.object(Classification, "get_train_data", return_value=(images, labels, size_train))
-        mock_get_list = mocker.patch.object(Classification, "get_list_images_per_class", return_value=list(range(10)))
-
-        set_data = mock_classification_class.load_data_train()
-
-        mock_get_data_train.assert_called_once_with()
-        mock_get_list.assert_called_once_with(labels)
-        assert_array_equal(set_data['classes'], str2ascii(classes_classification))
-        assert_array_equal(set_data['images'], images.reshape(size_train, 28, 28))
-        assert_array_equal(set_data['labels'], labels)
-        assert_array_equal(set_data['object_fields'], str2ascii(['images', 'labels']))
-        assert_array_equal(set_data['object_ids'], np.array([[i, labels[i]] for i in range(size_train)]))
-        assert set_data['list_images_per_class'] == list(range(10))
-
     def test_get_train_data(self, mocker, mock_classification_class):
         mock_load_images = mocker.patch.object(Classification, "load_images_numpy", return_value=np.zeros((5,768)))
         mock_load_labels = mocker.patch.object(Classification, "load_labels_numpy", return_value=np.ones(5))


### PR DESCRIPTION
This PR addresses #140 and adds unit tests to the `mnist dataset` . Also, the load_data() method code has been refactored to eliminate repetitive code.