### PR TITLE
[Update] move cifar10 annotation file read method to a separate class method 

### DIFF
--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -107,8 +107,6 @@ class Classification(BaseTaskNew):
         labels = np.array(batch['labels'], dtype=np.uint8)
         return data, labels
 
-
-
     def get_object_list(self, data, labels):
         """Groups the data + labels to a list of indexes."""
         object_id = np.ndarray((data.shape[0], 2), dtype=np.int32)

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -38,9 +38,7 @@ class Classification(BaseTaskNew):
         yield {"test": self.load_data_set(is_test=True)}
 
     def load_data_set(self, is_test):
-        """
-        Fetches the train/test data.
-        """
+        """Fetches the train/test data."""
         assert isinstance(is_test, bool), "Must input a valid boolean input."
         images, labels, class_names = self.load_data_annotations(is_test)
 

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -88,7 +88,7 @@ class Classification(BaseTaskNew):
             (batch1['data'], batch2['data'], batch3['data'], batch4['data'], batch5['data']),
             axis=0
         )
-        data = data.reshape((50000, 3, 32, 32))
+        data = self.reshape_array(data, 50000)
         labels = np.concatenate(
             (batch1['labels'], batch2['labels'], batch3['labels'], batch4['labels'], batch5['labels']),
             axis=0
@@ -96,12 +96,18 @@ class Classification(BaseTaskNew):
 
         return data, labels
 
+    def reshape_array(self, data, size_array):
+        """Reshapes the numpy array to a fixed format."""
+        return data.reshape(size_array, 3, 32, 32)
+
     def get_data_test(self, path):
         assert path, "Must input a valid path."
         batch = self.load_annotation_file(os.path.join(path, self.data_files[6]))
-        data = batch['data'].reshape(10000, 3, 32, 32)
+        data = self.reshape_array(batch['data'], 10000)
         labels = np.array(batch['labels'], dtype=np.uint8)
         return data, labels
+
+
 
     def get_object_list(self, data, labels):
         """Groups the data + labels to a list of indexes."""

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -70,14 +70,19 @@ class Classification(BaseTaskNew):
         """Returns the class names/labels."""
         assert path, "Must input a valid path."
         filename = os.path.join(path, self.data_files[0])
-        return load_pickle(filename)
+        return self.load_annotation_file(filename)
+
+    def load_annotation_file(self, path):
+        """Reads the data from annotation file from disk."""
+        return load_pickle(path)
 
     def get_data_train(self, path):
-        batch1 = load_pickle(os.path.join(path, self.data_files[1]))
-        batch2 = load_pickle(os.path.join(path, self.data_files[2]))
-        batch3 = load_pickle(os.path.join(path, self.data_files[3]))
-        batch4 = load_pickle(os.path.join(path, self.data_files[4]))
-        batch5 = load_pickle(os.path.join(path, self.data_files[5]))
+        assert path, "Must input a valid path."
+        batch1 = self.load_annotation_file(os.path.join(path, self.data_files[1]))
+        batch2 = self.load_annotation_file(os.path.join(path, self.data_files[2]))
+        batch3 = self.load_annotation_file(os.path.join(path, self.data_files[3]))
+        batch4 = self.load_annotation_file(os.path.join(path, self.data_files[4]))
+        batch5 = self.load_annotation_file(os.path.join(path, self.data_files[5]))
 
         data = np.concatenate(
             (batch1['data'], batch2['data'], batch3['data'], batch4['data'], batch5['data']),
@@ -92,7 +97,8 @@ class Classification(BaseTaskNew):
         return data, labels
 
     def get_data_test(self, path):
-        batch = load_pickle(os.path.join(path, self.data_files[6]))
+        assert path, "Must input a valid path."
+        batch = self.load_annotation_file(os.path.join(path, self.data_files[6]))
         data = batch['data'].reshape(10000, 3, 32, 32)
         labels = np.array(batch['labels'], dtype=np.uint8)
         return data, labels

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -94,6 +94,30 @@ class TestClassificationTask:
         mock_load_annot_file.assert_called_once_with(filename)
         assert result == 'dummy_data'
 
+    def test_get_data_train(self, mocker, mock_classification_class):
+        test_data = {
+            "data": np.random.rand(10000, 3*32*32),
+            "labels": np.random.randint(0, 9, (10000,))
+        }
+        mock_load_annot_file = mocker.patch.object(Classification, "load_annotation_file", return_value=test_data)
+
+        path = mock_classification_class.data_path
+        data, labels = mock_classification_class.get_data_train(path)
+
+        expected_data = np.concatenate(
+            (test_data['data'], test_data['data'], test_data['data'], test_data['data'], test_data['data']),
+            axis=0
+        ).reshape((50000, 3, 32, 32))
+        expected_labels = np.concatenate(
+            (test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels']),
+            axis=0
+        )
+
+        assert mock_load_annot_file.called
+        assert mock_load_annot_file.call_count == 5
+        assert_array_equal(data, expected_data)
+        assert_array_equal(labels, expected_labels)
+
     def test_get_object_list(self, mocker, mock_classification_class):
         data = np.random.rand(20,2,32,32)
         labels = np.array(range(20))

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -113,10 +113,12 @@ class TestClassificationTask:
             axis=0
         )
 
-        assert mock_load_annot_file.called
-        assert mock_load_annot_file.call_count == 5
-        assert_array_equal(data, expected_data)
-        assert_array_equal(labels, expected_labels)
+    def test_reshape_array(self, mocker, mock_classification_class):
+        data = np.random.rand(20, 3*32*32)
+
+        result = mock_classification_class.reshape_array(data, 20)
+
+        assert_array_equal(result, data.reshape(20, 3, 32, 32))
 
     def test_get_data_test(self, mocker, mock_classification_class):
         test_data = {

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -84,6 +84,16 @@ class TestClassificationTask:
         assert_array_equal(labels, np.array(range(10)))
         assert class_names == ['some', 'class', 'names']
 
+    def test_get_class_names(self, mocker, mock_classification_class):
+        mock_load_annot_file = mocker.patch.object(Classification, "load_annotation_file", return_value='dummy_data')
+
+        path = mock_classification_class.data_path
+        result = mock_classification_class.get_class_names(path)
+
+        filename = os.path.join(path, "batches.meta")
+        mock_load_annot_file.assert_called_once_with(filename)
+        assert result == 'dummy_data'
+
     def test_get_object_list(self, mocker, mock_classification_class):
         data = np.random.rand(20,2,32,32)
         labels = np.array(range(20))

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -113,7 +113,7 @@ class TestClassificationTask:
         assert mock_load_annot_file.called
         assert mock_load_annot_file.call_count == 5
         #mock_reshape_array.assert_called_once_with(test_data_concat, 50000)
-        mock_reshape_array.assert_called_once()
+        assert mock_reshape_array.called
         assert_array_equal(data, output_data)
         assert_array_equal(labels, np.concatenate(
             (test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels']),

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -118,6 +118,20 @@ class TestClassificationTask:
         assert_array_equal(data, expected_data)
         assert_array_equal(labels, expected_labels)
 
+    def test_get_data_test(self, mocker, mock_classification_class):
+        test_data = {
+            "data": np.random.rand(10000, 3*32*32),
+            "labels": np.random.randint(0, 9, (10000,))
+        }
+        mock_load_annot_file = mocker.patch.object(Classification, "load_annotation_file", return_value=test_data)
+
+        path = mock_classification_class.data_path
+        data, labels = mock_classification_class.get_data_test(path)
+
+        mock_load_annot_file.assert_called_once_with(os.path.join(path, 'test_batch'))
+        assert_array_equal(data, test_data['data'].reshape((10000, 3, 32, 32)))
+        assert_array_equal(labels, test_data['labels'])
+
     def test_get_object_list(self, mocker, mock_classification_class):
         data = np.random.rand(20,2,32,32)
         labels = np.array(range(20))

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -96,21 +96,28 @@ class TestClassificationTask:
 
     def test_get_data_train(self, mocker, mock_classification_class):
         test_data = {
-            "data": np.random.rand(10000, 3*32*32),
-            "labels": np.random.randint(0, 9, (10000,))
+            "data": np.random.rand(10, 3*32*32),
+            "labels": np.random.randint(0, 9, (10,))
         }
+        test_data_concat = np.concatenate(
+            (test_data['data'], test_data['data'], test_data['data'], test_data['data'], test_data['data']),
+            axis=0
+        )
+        output_data = test_data_concat.reshape(50,3,32,32)
         mock_load_annot_file = mocker.patch.object(Classification, "load_annotation_file", return_value=test_data)
+        mock_reshape_array = mocker.patch.object(Classification, "reshape_array", return_value=output_data)
 
         path = mock_classification_class.data_path
         data, labels = mock_classification_class.get_data_train(path)
 
-        expected_data = np.concatenate(
-            (test_data['data'], test_data['data'], test_data['data'], test_data['data'], test_data['data']),
-            axis=0
-        ).reshape((50000, 3, 32, 32))
-        expected_labels = np.concatenate(
+        assert mock_load_annot_file.called
+        assert mock_load_annot_file.call_count == 5
+        #mock_reshape_array.assert_called_once_with(test_data_concat, 50000)
+        mock_reshape_array.assert_called_once()
+        assert_array_equal(data, output_data)
+        assert_array_equal(labels, np.concatenate(
             (test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels'], test_data['labels']),
-            axis=0
+            axis=0)
         )
 
     def test_reshape_array(self, mocker, mock_classification_class):
@@ -122,16 +129,18 @@ class TestClassificationTask:
 
     def test_get_data_test(self, mocker, mock_classification_class):
         test_data = {
-            "data": np.random.rand(10000, 3*32*32),
-            "labels": np.random.randint(0, 9, (10000,))
+            "data": np.random.rand(10, 3*32*32),
+            "labels": np.random.randint(0, 9, (10,))
         }
         mock_load_annot_file = mocker.patch.object(Classification, "load_annotation_file", return_value=test_data)
+        mock_reshape_array = mocker.patch.object(Classification, "reshape_array", return_value=test_data['data'].reshape(10, 3, 32, 32))
 
         path = mock_classification_class.data_path
         data, labels = mock_classification_class.get_data_test(path)
 
         mock_load_annot_file.assert_called_once_with(os.path.join(path, 'test_batch'))
-        assert_array_equal(data, test_data['data'].reshape((10000, 3, 32, 32)))
+        mock_reshape_array.assert_called_once_with(test_data['data'], 10000)
+        assert_array_equal(data, test_data['data'].reshape((10, 3, 32, 32)))
         assert_array_equal(labels, test_data['labels'])
 
     def test_get_object_list(self, mocker, mock_classification_class):


### PR DESCRIPTION
This PR fixes #143 by moving the refactoring how the annotation data is read by using a separate class method to improve unit testing. Also, this detaches the data loading method from the class and makes it easier to replace it in the future if needed.