### PR TITLE
Fix typo in of the mpii pose dataset README

### DIFF
--- a/dbcollection/datasets/mpii_pose/README.rst
+++ b/dbcollection/datasets/mpii_pose/README.rst
@@ -52,8 +52,8 @@ How to use
     >>> import dbcollection as dbc
     >>>
     >>> # load the dataset
-    >>> mnist = dbc.load('mpii_pose', 'keypoints')
-    >>> mnist
+    >>> mpii_pose = dbc.load('mpii_pose')
+    >>> mpii_pose
     DataLoader: "mpii_pose" (keypoints task)
 
 


### PR DESCRIPTION
This PR fixes a typo in the `mpii_pose` dataset's `README.rst`.