### PR TITLE
[Refactor] convert cifar10 dataset to column format

### DIFF
--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -59,7 +59,7 @@ class Classification(BaseTask):
         if self.verbose:
             print('\n==> Setting up the data fields:')
         ClassLabelField(**args).process()
-        image_ids = ImageField(**args).process()
+        ImageField(**args).process()
         LabelIdField(**args).process()
         ColumnField(**args).process()
 
@@ -186,7 +186,7 @@ class ImageField(BaseField):
     @display_message_processing('images')
     def process(self):
         """Processes and saves the images metadata to hdf5."""
-        images, image_ids = self.get_images()
+        images = self.get_images()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='images',
@@ -194,14 +194,10 @@ class ImageField(BaseField):
             dtype=np.uint8,
             fillvalue=-1
         )
-        return image_ids
 
     def get_images(self):
-        """Returns a np.ndarray of images and a list
-        of image ids for each row of 'object_ids' field."""
-        images = self.data['images']
-        image_ids = list(range(len(images)))
-        return images, image_ids
+        """Returns a np.ndarray of images."""
+        return self.data['images']
 
 
 class LabelIdField(BaseField):

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -61,8 +61,6 @@ class Classification(BaseTask):
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
-        ObjectFieldNamesField(**args).process()
-        ObjectIdsField(**args).process(image_ids, label_ids)
 
         # Lists
         if self.verbose:
@@ -227,36 +225,6 @@ class LabelIdField(BaseField):
         labels = self.data['labels']
         label_ids = list(range(len(labels)))
         return labels, label_ids
-
-
-class ObjectFieldNamesField(BaseField):
-    """Object field names metadata process/save class."""
-
-    def process(self):
-        """Processes and saves the labels metadata to hdf5."""
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_fields',
-            data=str2ascii(['images', 'labels']),
-            dtype=np.uint8,
-            fillvalue=0
-        )
-
-
-class ObjectIdsField(BaseField):
-    """Object ids' field metadata process/save class."""
-
-    def process(self, image_ids, label_ids):
-        """Processes and saves the object ids metadata to hdf5."""
-        # images, labels
-        object_ids = [[image_ids[i], label_ids[i]] for i, _ in enumerate(label_ids)]
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_ids',
-            data=np.array(object_ids, dtype=np.int32),
-            dtype=np.int32,
-            fillvalue=-1
-        )
 
 
 # -----------------------------------------------------------

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -60,7 +60,7 @@ class Classification(BaseTask):
             print('\n==> Setting up the data fields:')
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
-        label_ids = LabelIdField(**args).process()
+        LabelIdField(**args).process()
         ColumnField(**args).process()
 
         # Lists
@@ -210,7 +210,7 @@ class LabelIdField(BaseField):
     @display_message_processing('labels')
     def process(self):
         """Processes and saves the labels metadata to hdf5."""
-        labels, label_ids = self.get_labels()
+        labels = self.get_labels()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='labels',
@@ -218,14 +218,10 @@ class LabelIdField(BaseField):
             dtype=np.uint8,
             fillvalue=0
         )
-        return label_ids
 
     def get_labels(self):
-        """Returns a np.ndarray of labels and a list
-        of label ids for each row of 'object_ids' field."""
-        labels = self.data['labels']
-        label_ids = list(range(len(labels)))
-        return labels, label_ids
+        """Returns a np.ndarray of labels."""
+        return self.data['labels']
 
 
 class ColumnField(BaseColumnField):

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 import os
 import numpy as np
 
-from dbcollection.datasets import BaseTask, BaseField
+from dbcollection.datasets import BaseTask, BaseField, BaseColumnField
 from dbcollection.utils.decorators import display_message_processing
 from dbcollection.utils.file_load import load_pickle
 from dbcollection.utils.string_ascii import convert_str_to_ascii as str2ascii
@@ -61,6 +61,7 @@ class Classification(BaseTask):
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
+        ColumnField(**args).process()
 
         # Lists
         if self.verbose:
@@ -225,6 +226,15 @@ class LabelIdField(BaseField):
         labels = self.data['labels']
         label_ids = list(range(len(labels)))
         return labels, label_ids
+
+
+class ColumnField(BaseColumnField):
+    """Column names' field metadata process/save class."""
+
+    fields = [
+        'images',
+        'labels'
+    ]
 
 
 # -----------------------------------------------------------

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -63,7 +63,7 @@ class TestClassificationTask:
         dummy_ids = [0, 1, 2, 3, 4, 5]
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
-        mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
+        mock_label_field = mocker.patch.object(LabelIdField, "process")
         mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
@@ -323,13 +323,11 @@ class TestLabelIdField:
 
     def test_process(self, mocker, mock_label_class):
         dummy_labels = np.array(range(10))
-        dummy_ids = list(range(10))
-        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=(dummy_labels, dummy_ids))
+        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=dummy_labels)
         mock_save_hdf5 = mocker.patch.object(LabelIdField, "save_field_to_hdf5")
 
-        label_ids = mock_label_class.process()
+        mock_label_class.process()
 
-        assert label_ids == dummy_ids
         mock_get_labels.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -342,10 +340,9 @@ class TestLabelIdField:
         # )
 
     def test_get_images(self, mocker, mock_label_class, test_data_loaded):
-        labels, label_ids = mock_label_class.get_labels()
+        labels = mock_label_class.get_labels()
 
         assert_array_equal(labels, test_data_loaded['labels'])
-        assert label_ids == list(range(len(labels)))
 
 
 class TestColumnField:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -60,9 +60,8 @@ class TestClassificationTask:
         assert test_data == {"test": ['some_data']}
 
     def test_process_set_metadata(self, mocker, mock_classification_class):
-        dummy_ids = [0, 1, 2, 3, 4, 5]
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
-        mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
+        mock_image_field = mocker.patch.object(ImageField, "process")
         mock_label_field = mocker.patch.object(LabelIdField, "process")
         mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
@@ -273,9 +272,7 @@ class TestClassLabelField:
         # )
 
     def test_get_class_names(self, mocker, mock_classlabel_class, test_data_loaded):
-        class_names = mock_classlabel_class.get_class_names()
-
-        assert class_names == test_data_loaded['classes']
+        assert mock_classlabel_class.get_class_names() == test_data_loaded['classes']
 
 
 class TestImageField:
@@ -288,13 +285,11 @@ class TestImageField:
 
     def test_process(self, mocker, mock_image_class):
         dummy_images = np.random.rand(5,3, 32, 32)
-        dummy_ids = list(range(5))
-        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=(dummy_images, dummy_ids))
+        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=dummy_images)
         mock_save_hdf5 = mocker.patch.object(ImageField, "save_field_to_hdf5")
 
-        image_ids = mock_image_class.process()
+        mock_image_class.process()
 
-        assert image_ids == dummy_ids
         mock_get_images.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -307,10 +302,7 @@ class TestImageField:
         # )
 
     def test_get_images(self, mocker, mock_image_class, test_data_loaded):
-        images, image_ids = mock_image_class.get_images()
-
-        assert_array_equal(images, test_data_loaded['images'])
-        assert image_ids == list(range(len(images)))
+        assert_array_equal(mock_image_class.get_images(), test_data_loaded['images'])
 
 
 class TestLabelIdField:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -15,6 +15,7 @@ from dbcollection.datasets.cifar.cifar10.classification import (
     Classification,
     DatasetAnnotationLoader,
     ClassLabelField,
+    ColumnField,
     ImageField,
     LabelIdField,
     ImagesPerClassList
@@ -63,6 +64,7 @@ class TestClassificationTask:
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
+        mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
         data = {"classes": 1, "images": 1, "labels": 1,
@@ -72,6 +74,7 @@ class TestClassificationTask:
         mock_class_field.assert_called_once_with()
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
+        mock_column_field.assert_called_once_with()
         mock_images_per_class_list.assert_called_once_with()
 
 
@@ -343,6 +346,17 @@ class TestLabelIdField:
 
         assert_array_equal(labels, test_data_loaded['labels'])
         assert label_ids == list(range(len(labels)))
+
+
+class TestColumnField:
+    """Unit tests for the ColumnField class."""
+
+    def test_field_attributes(self):
+        column_fields = ColumnField()
+        assert column_fields.fields == [
+            'images',
+            'labels'
+        ]
 
 
 class TestImagesPerClassList:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -17,8 +17,6 @@ from dbcollection.datasets.cifar.cifar10.classification import (
     ClassLabelField,
     ImageField,
     LabelIdField,
-    ObjectFieldNamesField,
-    ObjectIdsField,
     ImagesPerClassList
 )
 
@@ -65,8 +63,6 @@ class TestClassificationTask:
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
-        mock_objfield_field = mocker.patch.object(ObjectFieldNamesField, "process")
-        mock_objids_field = mocker.patch.object(ObjectIdsField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
         data = {"classes": 1, "images": 1, "labels": 1,
@@ -76,8 +72,6 @@ class TestClassificationTask:
         mock_class_field.assert_called_once_with()
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
-        mock_objfield_field.assert_called_once_with()
-        mock_objids_field.assert_called_once_with(dummy_ids, dummy_ids)
         mock_images_per_class_list.assert_called_once_with()
 
 
@@ -349,59 +343,6 @@ class TestLabelIdField:
 
         assert_array_equal(labels, test_data_loaded['labels'])
         assert label_ids == list(range(len(labels)))
-
-
-class TestObjectFieldNamesField:
-    """Unit tests for the ObjectFieldNamesField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfields_class(field_kwargs):
-        return ObjectFieldNamesField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfields_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectFieldNamesField, "save_field_to_hdf5")
-
-        mock_objfields_class.process()
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_fields',
-        #     data=str2ascii(['images', 'labels']),
-        #     dtype=np.uint8,
-        #     fillvalue=0
-        # )
-
-
-class TestObjectIdsField:
-    """Unit tests for the ObjectIdsField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfids_class(field_kwargs):
-        return ObjectIdsField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfids_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectIdsField, "save_field_to_hdf5")
-
-        image_ids = [0, 1, 2, 3, 4, 5]
-        label_ids = [1, 5, 9, 8, 3, 5]
-        object_ids = mock_objfids_class.process(
-            image_ids=image_ids,
-            label_ids=label_ids
-        )
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_ids',
-        #     data=np.array([[0, 1], [1, 5], [2, 9], [3, 8], [4, 3], [5, 5]], dtype=np.int32),
-        #     dtype=np.int32,
-        #     fillvalue=-1
-        # )
 
 
 class TestImagesPerClassList:


### PR DESCRIPTION
This PR addresses #168 and converts the metadata format for the `cifar10` dataset to a column-based format. The fields `object_fields` and `object_ids` were removed and replaced with a custom column field for aggregating the different data fields.