### PR TITLE
[Refactor] convert cifar10 dataset to column format

### DIFF
--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -59,7 +59,7 @@ class Classification(BaseTask):
         if self.verbose:
             print('\n==> Setting up the data fields:')
         ClassLabelField(**args).process()
-        image_ids = ImageField(**args).process()
+        ImageField(**args).process()
         LabelIdField(**args).process()
         ColumnField(**args).process()
 
@@ -186,7 +186,7 @@ class ImageField(BaseField):
     @display_message_processing('images')
     def process(self):
         """Processes and saves the images metadata to hdf5."""
-        images, image_ids = self.get_images()
+        images = self.get_images()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='images',
@@ -194,14 +194,10 @@ class ImageField(BaseField):
             dtype=np.uint8,
             fillvalue=-1
         )
-        return image_ids
 
     def get_images(self):
-        """Returns a np.ndarray of images and a list
-        of image ids for each row of 'object_ids' field."""
-        images = self.data['images']
-        image_ids = list(range(len(images)))
-        return images, image_ids
+        """Returns a np.ndarray of images."""
+        return self.data['images']
 
 
 class LabelIdField(BaseField):

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -61,8 +61,6 @@ class Classification(BaseTask):
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
-        ObjectFieldNamesField(**args).process()
-        ObjectIdsField(**args).process(image_ids, label_ids)
 
         # Lists
         if self.verbose:
@@ -227,36 +225,6 @@ class LabelIdField(BaseField):
         labels = self.data['labels']
         label_ids = list(range(len(labels)))
         return labels, label_ids
-
-
-class ObjectFieldNamesField(BaseField):
-    """Object field names metadata process/save class."""
-
-    def process(self):
-        """Processes and saves the labels metadata to hdf5."""
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_fields',
-            data=str2ascii(['images', 'labels']),
-            dtype=np.uint8,
-            fillvalue=0
-        )
-
-
-class ObjectIdsField(BaseField):
-    """Object ids' field metadata process/save class."""
-
-    def process(self, image_ids, label_ids):
-        """Processes and saves the object ids metadata to hdf5."""
-        # images, labels
-        object_ids = [[image_ids[i], label_ids[i]] for i, _ in enumerate(label_ids)]
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_ids',
-            data=np.array(object_ids, dtype=np.int32),
-            dtype=np.int32,
-            fillvalue=-1
-        )
 
 
 # -----------------------------------------------------------

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -60,7 +60,7 @@ class Classification(BaseTask):
             print('\n==> Setting up the data fields:')
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
-        label_ids = LabelIdField(**args).process()
+        LabelIdField(**args).process()
         ColumnField(**args).process()
 
         # Lists
@@ -210,7 +210,7 @@ class LabelIdField(BaseField):
     @display_message_processing('labels')
     def process(self):
         """Processes and saves the labels metadata to hdf5."""
-        labels, label_ids = self.get_labels()
+        labels = self.get_labels()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='labels',
@@ -218,14 +218,10 @@ class LabelIdField(BaseField):
             dtype=np.uint8,
             fillvalue=0
         )
-        return label_ids
 
     def get_labels(self):
-        """Returns a np.ndarray of labels and a list
-        of label ids for each row of 'object_ids' field."""
-        labels = self.data['labels']
-        label_ids = list(range(len(labels)))
-        return labels, label_ids
+        """Returns a np.ndarray of labels."""
+        return self.data['labels']
 
 
 class ColumnField(BaseColumnField):

--- a/dbcollection/datasets/cifar/cifar10/classification.py
+++ b/dbcollection/datasets/cifar/cifar10/classification.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 import os
 import numpy as np
 
-from dbcollection.datasets import BaseTask, BaseField
+from dbcollection.datasets import BaseTask, BaseField, BaseColumnField
 from dbcollection.utils.decorators import display_message_processing
 from dbcollection.utils.file_load import load_pickle
 from dbcollection.utils.string_ascii import convert_str_to_ascii as str2ascii
@@ -61,6 +61,7 @@ class Classification(BaseTask):
         ClassLabelField(**args).process()
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
+        ColumnField(**args).process()
 
         # Lists
         if self.verbose:
@@ -225,6 +226,15 @@ class LabelIdField(BaseField):
         labels = self.data['labels']
         label_ids = list(range(len(labels)))
         return labels, label_ids
+
+
+class ColumnField(BaseColumnField):
+    """Column names' field metadata process/save class."""
+
+    fields = [
+        'images',
+        'labels'
+    ]
 
 
 # -----------------------------------------------------------

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 import os
 import numpy as np
 
-from dbcollection.datasets import BaseTask, BaseField
+from dbcollection.datasets import BaseTask, BaseField, BaseColumnField
 from dbcollection.utils.decorators import display_message_processing
 from dbcollection.utils.file_load import load_pickle
 from dbcollection.utils.string_ascii import convert_str_to_ascii as str2ascii
@@ -108,6 +108,7 @@ class Classification(BaseTask):
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
         super_label_ids = SuperLabelIdField(**args).process()
+        ColumnField(**args).process()
 
         # Lists
         if self.verbose:
@@ -302,6 +303,15 @@ class SuperLabelIdField(BaseField):
         super_label_ids = list(range(len(super_labels)))
         return super_labels, super_label_ids
 
+
+class ColumnField(BaseColumnField):
+    """Column names' field metadata process/save class."""
+
+    fields = [
+        'images',
+        'labels',
+        'superlabels'
+    ]
 
 # -----------------------------------------------------------
 # Metadata lists

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -108,8 +108,6 @@ class Classification(BaseTask):
         image_ids = ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
         super_label_ids = SuperLabelIdField(**args).process()
-        ObjectFieldNamesField(**args).process()
-        ObjectIdsField(**args).process(image_ids, label_ids, super_label_ids)
 
         # Lists
         if self.verbose:
@@ -303,36 +301,6 @@ class SuperLabelIdField(BaseField):
         super_labels = self.data['coarse_labels']
         super_label_ids = list(range(len(super_labels)))
         return super_labels, super_label_ids
-
-
-class ObjectFieldNamesField(BaseField):
-    """Object field names metadata process/save class."""
-
-    def process(self):
-        """Processes and saves the labels metadata to hdf5."""
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_fields',
-            data=str2ascii(['images', 'labels', 'superlabels']),
-            dtype=np.uint8,
-            fillvalue=0
-        )
-
-
-class ObjectIdsField(BaseField):
-    """Object ids' field metadata process/save class."""
-
-    def process(self, image_ids, label_ids, super_label_ids):
-        """Processes and saves the object ids metadata to hdf5."""
-        # images, labels, superlabels
-        object_ids = [[image_ids[i], label_ids[i], super_label_ids[i]] for i, _ in enumerate(label_ids)]
-        self.save_field_to_hdf5(
-            set_name=self.set_name,
-            field='object_ids',
-            data=np.array(object_ids, dtype=np.int32),
-            dtype=np.int32,
-            fillvalue=-1
-        )
 
 
 # -----------------------------------------------------------

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -209,7 +209,10 @@ class ClassLabelField(BaseField):
 
     def get_class_names(self):
         """Returns a list of class names."""
-        return self.data['classes']
+        label_names = self.data['classes']
+        label_ids = self.data['labels']
+        class_names = [label_names[idx] for idx in label_ids]
+        return class_names
 
 
 class SuperClassLabelField(BaseField):
@@ -229,7 +232,10 @@ class SuperClassLabelField(BaseField):
 
     def get_class_names(self):
         """Returns a list of super class names."""
-        return self.data['coarse_classes']
+        coarse_label_names = self.data['coarse_classes']
+        coarse_label_ids = self.data['coarse_labels']
+        coarse_class_names = [coarse_label_names[idx] for idx in coarse_label_ids]
+        return coarse_class_names
 
 
 class ImageField(BaseField):
@@ -298,8 +304,11 @@ class ColumnField(BaseColumnField):
     fields = [
         'images',
         'labels',
+        'classes',
         'superlabels'
+        'superclasses',
     ]
+
 
 # -----------------------------------------------------------
 # Metadata lists

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -105,7 +105,7 @@ class Classification(BaseTask):
             print('\n==> Setting up the data fields:')
         ClassLabelField(**args).process()
         SuperClassLabelField(**args).process()
-        image_ids = ImageField(**args).process()
+        ImageField(**args).process()
         label_ids = LabelIdField(**args).process()
         super_label_ids = SuperLabelIdField(**args).process()
         ColumnField(**args).process()
@@ -238,7 +238,7 @@ class ImageField(BaseField):
     @display_message_processing('images')
     def process(self):
         """Processes and saves the images metadata to hdf5."""
-        images, image_ids = self.get_images()
+        images = self.get_images()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='images',
@@ -246,14 +246,10 @@ class ImageField(BaseField):
             dtype=np.uint8,
             fillvalue=-1
         )
-        return image_ids
 
     def get_images(self):
-        """Returns a np.ndarray of images and a list
-        of image ids for each row of 'object_ids' field."""
-        images = self.data['images']
-        image_ids = list(range(len(images)))
-        return images, image_ids
+        """Returns a np.ndarray of images."""
+        return self.data['images']
 
 
 class LabelIdField(BaseField):

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -106,7 +106,7 @@ class Classification(BaseTask):
         ClassLabelField(**args).process()
         SuperClassLabelField(**args).process()
         ImageField(**args).process()
-        label_ids = LabelIdField(**args).process()
+        LabelIdField(**args).process()
         super_label_ids = SuperLabelIdField(**args).process()
         ColumnField(**args).process()
 
@@ -258,7 +258,7 @@ class LabelIdField(BaseField):
     @display_message_processing('labels')
     def process(self):
         """Processes and saves the labels metadata to hdf5."""
-        labels, label_ids = self.get_labels()
+        labels = self.get_labels()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='labels',
@@ -266,14 +266,10 @@ class LabelIdField(BaseField):
             dtype=np.uint8,
             fillvalue=0
         )
-        return label_ids
 
     def get_labels(self):
-        """Returns a np.ndarray of labels and a list
-        of label ids for each row of 'object_ids' field."""
-        labels = self.data['labels']
-        label_ids = list(range(len(labels)))
-        return labels, label_ids
+        """Returns a np.ndarray of labels."""
+        return self.data['labels']
 
 
 class SuperLabelIdField(BaseField):

--- a/dbcollection/datasets/cifar/cifar100/classification.py
+++ b/dbcollection/datasets/cifar/cifar100/classification.py
@@ -107,7 +107,7 @@ class Classification(BaseTask):
         SuperClassLabelField(**args).process()
         ImageField(**args).process()
         LabelIdField(**args).process()
-        super_label_ids = SuperLabelIdField(**args).process()
+        SuperLabelIdField(**args).process()
         ColumnField(**args).process()
 
         # Lists
@@ -278,7 +278,7 @@ class SuperLabelIdField(BaseField):
     @display_message_processing('super labels')
     def process(self):
         """Processes and saves the super labels metadata to hdf5."""
-        super_labels, super_label_ids = self.get_super_labels()
+        super_labels = self.get_super_labels()
         self.save_field_to_hdf5(
             set_name=self.set_name,
             field='superlabels',
@@ -286,14 +286,10 @@ class SuperLabelIdField(BaseField):
             dtype=np.uint8,
             fillvalue=0
         )
-        return super_label_ids
 
     def get_super_labels(self):
-        """Returns a np.ndarray of super labels and a list
-        of label ids for each row of 'object_ids' field."""
-        super_labels = self.data['coarse_labels']
-        super_label_ids = list(range(len(super_labels)))
-        return super_labels, super_label_ids
+        """Returns a np.ndarray of super labels."""
+        return self.data['coarse_labels']
 
 
 class ColumnField(BaseColumnField):

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -63,7 +63,7 @@ class TestClassificationTask:
         dummy_ids = [0, 1, 2, 3, 4, 5]
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
-        mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
+        mock_label_field = mocker.patch.object(LabelIdField, "process")
         mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
@@ -323,13 +323,11 @@ class TestLabelIdField:
 
     def test_process(self, mocker, mock_label_class):
         dummy_labels = np.array(range(10))
-        dummy_ids = list(range(10))
-        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=(dummy_labels, dummy_ids))
+        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=dummy_labels)
         mock_save_hdf5 = mocker.patch.object(LabelIdField, "save_field_to_hdf5")
 
-        label_ids = mock_label_class.process()
+        mock_label_class.process()
 
-        assert label_ids == dummy_ids
         mock_get_labels.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -342,10 +340,9 @@ class TestLabelIdField:
         # )
 
     def test_get_images(self, mocker, mock_label_class, test_data_loaded):
-        labels, label_ids = mock_label_class.get_labels()
+        labels = mock_label_class.get_labels()
 
         assert_array_equal(labels, test_data_loaded['labels'])
-        assert label_ids == list(range(len(labels)))
 
 
 class TestColumnField:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -60,9 +60,8 @@ class TestClassificationTask:
         assert test_data == {"test": ['some_data']}
 
     def test_process_set_metadata(self, mocker, mock_classification_class):
-        dummy_ids = [0, 1, 2, 3, 4, 5]
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
-        mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
+        mock_image_field = mocker.patch.object(ImageField, "process")
         mock_label_field = mocker.patch.object(LabelIdField, "process")
         mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
@@ -273,9 +272,7 @@ class TestClassLabelField:
         # )
 
     def test_get_class_names(self, mocker, mock_classlabel_class, test_data_loaded):
-        class_names = mock_classlabel_class.get_class_names()
-
-        assert class_names == test_data_loaded['classes']
+        assert mock_classlabel_class.get_class_names() == test_data_loaded['classes']
 
 
 class TestImageField:
@@ -288,13 +285,11 @@ class TestImageField:
 
     def test_process(self, mocker, mock_image_class):
         dummy_images = np.random.rand(5,3, 32, 32)
-        dummy_ids = list(range(5))
-        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=(dummy_images, dummy_ids))
+        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=dummy_images)
         mock_save_hdf5 = mocker.patch.object(ImageField, "save_field_to_hdf5")
 
-        image_ids = mock_image_class.process()
+        mock_image_class.process()
 
-        assert image_ids == dummy_ids
         mock_get_images.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -307,10 +302,7 @@ class TestImageField:
         # )
 
     def test_get_images(self, mocker, mock_image_class, test_data_loaded):
-        images, image_ids = mock_image_class.get_images()
-
-        assert_array_equal(images, test_data_loaded['images'])
-        assert image_ids == list(range(len(images)))
+        assert_array_equal(mock_image_class.get_images(), test_data_loaded['images'])
 
 
 class TestLabelIdField:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -15,6 +15,7 @@ from dbcollection.datasets.cifar.cifar10.classification import (
     Classification,
     DatasetAnnotationLoader,
     ClassLabelField,
+    ColumnField,
     ImageField,
     LabelIdField,
     ImagesPerClassList
@@ -63,6 +64,7 @@ class TestClassificationTask:
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
+        mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
         data = {"classes": 1, "images": 1, "labels": 1,
@@ -72,6 +74,7 @@ class TestClassificationTask:
         mock_class_field.assert_called_once_with()
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
+        mock_column_field.assert_called_once_with()
         mock_images_per_class_list.assert_called_once_with()
 
 
@@ -343,6 +346,17 @@ class TestLabelIdField:
 
         assert_array_equal(labels, test_data_loaded['labels'])
         assert label_ids == list(range(len(labels)))
+
+
+class TestColumnField:
+    """Unit tests for the ColumnField class."""
+
+    def test_field_attributes(self):
+        column_fields = ColumnField()
+        assert column_fields.fields == [
+            'images',
+            'labels'
+        ]
 
 
 class TestImagesPerClassList:

--- a/tests/datasets/test_cifar10.py
+++ b/tests/datasets/test_cifar10.py
@@ -17,8 +17,6 @@ from dbcollection.datasets.cifar.cifar10.classification import (
     ClassLabelField,
     ImageField,
     LabelIdField,
-    ObjectFieldNamesField,
-    ObjectIdsField,
     ImagesPerClassList
 )
 
@@ -65,8 +63,6 @@ class TestClassificationTask:
         mock_class_field = mocker.patch.object(ClassLabelField, "process")
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
-        mock_objfield_field = mocker.patch.object(ObjectFieldNamesField, "process")
-        mock_objids_field = mocker.patch.object(ObjectIdsField, "process")
         mock_images_per_class_list = mocker.patch.object(ImagesPerClassList, "process")
 
         data = {"classes": 1, "images": 1, "labels": 1,
@@ -76,8 +72,6 @@ class TestClassificationTask:
         mock_class_field.assert_called_once_with()
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
-        mock_objfield_field.assert_called_once_with()
-        mock_objids_field.assert_called_once_with(dummy_ids, dummy_ids)
         mock_images_per_class_list.assert_called_once_with()
 
 
@@ -349,59 +343,6 @@ class TestLabelIdField:
 
         assert_array_equal(labels, test_data_loaded['labels'])
         assert label_ids == list(range(len(labels)))
-
-
-class TestObjectFieldNamesField:
-    """Unit tests for the ObjectFieldNamesField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfields_class(field_kwargs):
-        return ObjectFieldNamesField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfields_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectFieldNamesField, "save_field_to_hdf5")
-
-        mock_objfields_class.process()
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_fields',
-        #     data=str2ascii(['images', 'labels']),
-        #     dtype=np.uint8,
-        #     fillvalue=0
-        # )
-
-
-class TestObjectIdsField:
-    """Unit tests for the ObjectIdsField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfids_class(field_kwargs):
-        return ObjectIdsField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfids_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectIdsField, "save_field_to_hdf5")
-
-        image_ids = [0, 1, 2, 3, 4, 5]
-        label_ids = [1, 5, 9, 8, 3, 5]
-        object_ids = mock_objfids_class.process(
-            image_ids=image_ids,
-            label_ids=label_ids
-        )
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_ids',
-        #     data=np.array([[0, 1], [1, 5], [2, 9], [3, 8], [4, 3], [5, 5]], dtype=np.int32),
-        #     dtype=np.int32,
-        #     fillvalue=-1
-        # )
 
 
 class TestImagesPerClassList:

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -365,13 +365,11 @@ class TestImageField:
 
     def test_process(self, mocker, mock_image_class):
         dummy_images = np.random.rand(5,3, 32, 32)
-        dummy_ids = list(range(5))
-        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=(dummy_images, dummy_ids))
+        mock_get_images = mocker.patch.object(ImageField, "get_images", return_value=dummy_images)
         mock_save_hdf5 = mocker.patch.object(ImageField, "save_field_to_hdf5")
 
-        image_ids = mock_image_class.process()
+        mock_image_class.process()
 
-        assert image_ids == dummy_ids
         mock_get_images.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -384,10 +382,7 @@ class TestImageField:
         # )
 
     def test_get_images(self, mocker, mock_image_class, test_data_loaded):
-        images, image_ids = mock_image_class.get_images()
-
-        assert_array_equal(images, test_data_loaded['images'])
-        assert image_ids == list(range(len(images)))
+        assert_array_equal(mock_image_class.get_images(), test_data_loaded['images'])
 
 
 class TestLabelIdField:

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -260,14 +260,43 @@ def test_data_loaded():
         'orchids', 'poppies', 'roses', 'sunflowers', 'tulips',
         'bottles', 'bowls', 'cans', 'cups', 'plates',
         'apples', 'mushrooms', 'oranges', 'pears', 'sweet peppers',
-        'clock', 'computer keyboard', 'lamp', 'telephone', 'television'
+        'clock', 'computer keyboard', 'lamp', 'telephone', 'television',
+        'bed', 'chair', 'couch', 'table', 'wardrobe',
+        'bee', 'beetle', 'butterfly', 'caterpillar', 'cockroach',
+        'bear', 'leopard', 'lion', 'tiger', 'wolf',
+        'bridge', 'castle', 'house', 'road', 'skyscraper',
+        'cloud', 'forest', 'mountain', 'plain', 'sea',
+        'camel', 'cattle', 'chimpanzee', 'elephant', 'kangaroo',
+        'fox', 'porcupine', 'possum', 'raccoon', 'skunk',
+        'crab', 'lobster', 'snail', 'spider', 'worm',
+        'baby', 'boy', 'girl', 'man', 'woman',
+        'crocodile', 'dinosaur', 'lizard', 'snake', 'turtle',
+        'hamster', 'mouse', 'rabbit', 'shrew', 'squirrel',
+        'maple', 'oak', 'palm', 'pine', 'willow',
+        'bicycle', 'bus', 'motorcycle', 'pickup truck', 'train',
+        'lawn-mower', 'rocket', 'streetcar', 'tank', 'tractor'
     ]
     coarse_classes = ['aquatic mammals',
+        'aquatic mammals',
         'fish',
         'flowers',
         'food containers',
         'fruit and vegetables',
-        'household electrical devices'
+        'household electrical devices',
+        'household furniture',
+        'insects',
+        'large carnivores',
+        'large man-made outdoor things',
+        'large natural outdoor scenes',
+        'large omnivores and herbivores',
+        'medium-sized mammals',
+        'non-insect invertebrates',
+        'people',
+        'reptiles',
+        'small mammals',
+        'trees',
+        'vehicles 1',
+        'vehicles 2',
     ]
     images = np.random.rand(10,3,32,32)
     labels = np.random.randint(0,100,10)
@@ -319,8 +348,8 @@ class TestClassLabelField:
 
     def test_get_class_names(self, mocker, mock_classlabel_class, test_data_loaded):
         class_names = mock_classlabel_class.get_class_names()
-
-        assert class_names == test_data_loaded['classes']
+        expected_names = [test_data_loaded['classes'][idx] for idx in test_data_loaded['labels']]
+        assert class_names == expected_names
 
 
 class TestSuperClassLabelField:
@@ -350,9 +379,9 @@ class TestSuperClassLabelField:
         # )
 
     def test_get_class_names(self, mocker, mock_coarseclasslabel_class, test_data_loaded):
-        class_names = mock_coarseclasslabel_class.get_class_names()
-
-        assert class_names == test_data_loaded['coarse_classes']
+        coarse_class_names = mock_coarseclasslabel_class.get_class_names()
+        expected_names = [test_data_loaded['coarse_classes'][idx] for idx in test_data_loaded['coarse_labels']]
+        assert coarse_class_names == expected_names
 
 
 class TestImageField:
@@ -453,7 +482,9 @@ class TestColumnField:
         assert column_fields.fields == [
             'images',
             'labels',
+            'classes',
             'superlabels'
+            'superclasses',
         ]
 
 

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -395,13 +395,11 @@ class TestLabelIdField:
 
     def test_process(self, mocker, mock_label_class):
         dummy_labels = np.array(range(10))
-        dummy_ids = list(range(10))
-        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=(dummy_labels, dummy_ids))
+        mock_get_labels = mocker.patch.object(LabelIdField, "get_labels", return_value=dummy_labels)
         mock_save_hdf5 = mocker.patch.object(LabelIdField, "save_field_to_hdf5")
 
-        label_ids = mock_label_class.process()
+        mock_label_class.process()
 
-        assert label_ids == dummy_ids
         mock_get_labels.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -414,10 +412,7 @@ class TestLabelIdField:
         # )
 
     def test_get_labels(self, mocker, mock_label_class, test_data_loaded):
-        labels, label_ids = mock_label_class.get_labels()
-
-        assert_array_equal(labels, test_data_loaded['labels'])
-        assert label_ids == list(range(len(labels)))
+        assert_array_equal(mock_label_class.get_labels(), test_data_loaded['labels'])
 
 
 class TestSuperLabelIdField:

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -19,8 +19,6 @@ from dbcollection.datasets.cifar.cifar100.classification import (
     ImageField,
     LabelIdField,
     SuperLabelIdField,
-    ObjectFieldNamesField,
-    ObjectIdsField,
     ImagesPerClassList,
     ImagesPerSuperClassList
 )
@@ -122,8 +120,6 @@ class TestClassificationTask:
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
         mock_superlabel_field = mocker.patch.object(SuperLabelIdField, "process", return_value=dummy_ids)
-        mock_objfields_field = mocker.patch.object(ObjectFieldNamesField, "process")
-        mock_objids_field = mocker.patch.object(ObjectIdsField, "process")
         mock_images_list = mocker.patch.object(ImagesPerClassList, "process")
         mock_images_super_list = mocker.patch.object(ImagesPerSuperClassList, "process")
 
@@ -136,8 +132,6 @@ class TestClassificationTask:
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
         mock_superlabel_field.assert_called_once_with()
-        mock_objfields_field.assert_called_once_with()
-        mock_objids_field.assert_called_once_with(dummy_ids, dummy_ids, dummy_ids)
         mock_images_list.assert_called_once_with()
         mock_images_super_list.assert_called_once_with()
 
@@ -461,61 +455,6 @@ class TestSuperLabelIdField:
 
         assert_array_equal(super_labels, test_data_loaded['coarse_labels'])
         assert super_label_ids == list(range(len(super_labels)))
-
-
-class TestObjectFieldNamesField:
-    """Unit tests for the ObjectFieldNamesField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfields_class(field_kwargs):
-        return ObjectFieldNamesField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfields_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectFieldNamesField, "save_field_to_hdf5")
-
-        mock_objfields_class.process()
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_fields',
-        #     data=str2ascii(['images', 'labels', 'superlabels']),
-        #     dtype=np.uint8,
-        #     fillvalue=0
-        # )
-
-
-class TestObjectIdsField:
-    """Unit tests for the ObjectIdsField class."""
-
-    @staticmethod
-    @pytest.fixture()
-    def mock_objfids_class(field_kwargs):
-        return ObjectIdsField(**field_kwargs)
-
-    def test_process(self, mocker, mock_objfids_class):
-        mock_save_hdf5 = mocker.patch.object(ObjectIdsField, "save_field_to_hdf5")
-
-        image_ids = [0, 1, 2, 3, 4, 5]
-        label_ids = [11, 35, 29, 8, 33, 45]
-        super_label_ids = [1, 5, 9, 8, 3, 5]
-        object_ids = mock_objfids_class.process(
-            image_ids=image_ids,
-            label_ids=label_ids,
-            super_label_ids=super_label_ids
-        )
-
-        assert mock_save_hdf5.called
-        # **disabled until I find a way to do assert calls with numpy arrays**
-        # mock_save_hdf5.assert_called_once_with(
-        #     set_name='train',
-        #     field='object_ids',
-        #     data=np.array([[0, 11, 1], [1, 35, 5], [2, 29, 9], [3, 8, 8], [4, 33, 3], [5, 45, 5]], dtype=np.int32),
-        #     dtype=np.int32,
-        #     fillvalue=-1
-        # )
 
 
 class TestImagesPerClassList:

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -15,6 +15,7 @@ from dbcollection.datasets.cifar.cifar100.classification import (
     Classification,
     DatasetAnnotationLoader,
     ClassLabelField,
+    ColumnField,
     SuperClassLabelField,
     ImageField,
     LabelIdField,
@@ -120,6 +121,7 @@ class TestClassificationTask:
         mock_image_field = mocker.patch.object(ImageField, "process", return_value=dummy_ids)
         mock_label_field = mocker.patch.object(LabelIdField, "process", return_value=dummy_ids)
         mock_superlabel_field = mocker.patch.object(SuperLabelIdField, "process", return_value=dummy_ids)
+        mock_column_field = mocker.patch.object(ColumnField, "process")
         mock_images_list = mocker.patch.object(ImagesPerClassList, "process")
         mock_images_super_list = mocker.patch.object(ImagesPerSuperClassList, "process")
 
@@ -132,6 +134,7 @@ class TestClassificationTask:
         mock_image_field.assert_called_once_with()
         mock_label_field.assert_called_once_with()
         mock_superlabel_field.assert_called_once_with()
+        mock_column_field.assert_called_once_with()
         mock_images_list.assert_called_once_with()
         mock_images_super_list.assert_called_once_with()
 
@@ -455,6 +458,18 @@ class TestSuperLabelIdField:
 
         assert_array_equal(super_labels, test_data_loaded['coarse_labels'])
         assert super_label_ids == list(range(len(super_labels)))
+
+
+class TestColumnField:
+    """Unit tests for the ColumnField class."""
+
+    def test_field_attributes(self):
+        column_fields = ColumnField()
+        assert column_fields.fields == [
+            'images',
+            'labels',
+            'superlabels'
+        ]
 
 
 class TestImagesPerClassList:

--- a/tests/datasets/test_cifar100.py
+++ b/tests/datasets/test_cifar100.py
@@ -425,13 +425,11 @@ class TestSuperLabelIdField:
 
     def test_process(self, mocker, mock_superlabel_class):
         dummy_labels = np.array(range(10))
-        dummy_ids = list(range(10))
-        mock_get_labels = mocker.patch.object(SuperLabelIdField, "get_super_labels", return_value=(dummy_labels, dummy_ids))
+        mock_get_labels = mocker.patch.object(SuperLabelIdField, "get_super_labels", return_value=dummy_labels)
         mock_save_hdf5 = mocker.patch.object(SuperLabelIdField, "save_field_to_hdf5")
 
-        super_label_ids = mock_superlabel_class.process()
+        mock_superlabel_class.process()
 
-        assert super_label_ids == dummy_ids
         mock_get_labels.assert_called_once_with()
         assert mock_save_hdf5.called
         # **disabled until I find a way to do assert calls with numpy arrays**
@@ -444,10 +442,7 @@ class TestSuperLabelIdField:
         # )
 
     def test_get_super_labels(self, mocker, mock_superlabel_class, test_data_loaded):
-        super_labels, super_label_ids = mock_superlabel_class.get_super_labels()
-
-        assert_array_equal(super_labels, test_data_loaded['coarse_labels'])
-        assert super_label_ids == list(range(len(super_labels)))
+        assert_array_equal(mock_superlabel_class.get_super_labels(), test_data_loaded['coarse_labels'])
 
 
 class TestColumnField:


### PR DESCRIPTION
This PR addresses #168 and converts the metadata format for the `cifar100` dataset to a column-based format. The fields `object_fields` and `object_ids` were removed and replaced with a custom column field for aggregating the different data fields.